### PR TITLE
Fix garbled streaming output (issue #23): UTF-16 edit_index + rune-safe deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ On startup, you'll see a banner with your health URL, API endpoints, and auth to
 | `AGENT_MODE_VARIANT` | `modern` | Agent-mode shim variant override: `modern` or `legacy` (takes precedence over the implicit variant of `AGENT_MODE`) |
 | `LOG_LEVEL` | `debug` | Log level (`debug` dumps every Z.AI request/response, SSE lines, and headers) |
 | `LOG_FORMAT` | `text` | Log format |
+| `STREAM_HOLDBACK` | `24` | Runes held back at the tail of a live stream so Z.AI `edit_content` tail-backtracks are absorbed before text reaches the client (`0` disables; see issue #23) |
 
 ---
 
@@ -503,6 +504,8 @@ print(resp.content[0].text)
 3. **Signature** — HMAC-SHA256 over `(sortedPayload | promptBase64 | timestamp)` with a salted bucket key derived from `SALT_KEY` and `timestamp / 300000`.
 
 4. **Streaming** — POST to `/api/v2/chat/completions` with `stream: true`, parse SSE chunks (`edit_content` with `edit_index`, `delta_content`, `content`, or OpenAI-style `choices[0].delta.content`), and forward as OpenAI-formatted SSE or Anthropic SSE events. Inline errors (HTTP 200 with `data.error`) are detected and surfaced. On `401`, the session is re-initialised and the request retried once.
+
+   Field semantics mirror the official Z.AI web frontend (`prod-fe` bundle): `edit_content` replaces the accumulated text from `edit_index` onward, where `edit_index` is a **UTF-16 code-unit offset** (JavaScript `String.substring` indexing — a missing `edit_index` defaults to `0`, i.e. full replacement); `content` is a **full replacement**; `delta_content` appends. Deltas forwarded to clients are always cut on rune boundaries and a small tail (`STREAM_HOLDBACK`) is kept pending, so trailing backtracks never surface as replacement-character garble (issue #23).
 
 ---
 

--- a/agent.go
+++ b/agent.go
@@ -47,6 +47,7 @@ import (
     "fmt"
     "regexp"
     "strings"
+    "unicode/utf8"
 )
 
 const agentToolStart = "<<<TOOL_CALL>>>"
@@ -659,10 +660,11 @@ var (
 
 const agentFenceJSON = "```json"
 
-// agentStreamKeep is how many trailing bytes the streaming interceptor keeps
-// un-flushed while no marker has matched: enough to cover a fence line plus a
-// partially received marker at its worst tolerated spelling, so neither can
-// ever leak as content.
+// agentStreamKeep is the minimum number of trailing bytes the streaming
+// interceptor keeps un-flushed while no marker has matched: enough to cover
+// a fence line plus a partially received marker at its worst tolerated
+// spelling, so neither can ever leak as content. The actual cut is pulled
+// back to a rune boundary, so up to 3 extra bytes may be held.
 const agentStreamKeep = agentWorstMarkerLen + len("```json\n") + 5
 
 // NormalizeAgentFences removes fence lines adjacent to tool-call markers from
@@ -977,11 +979,20 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
             // Hold back a window big enough for a fence line + partial marker
             // so neither can leak as content while split across chunks. A
             // marker reported incomplete keeps its bytes inside this window,
-            // so nothing here can be part of a future match.
+            // so nothing here can be part of a future match. The cut is
+            // backed up to a rune boundary so a multi-byte character is
+            // never split across emissions (invalid UTF-8 would render as
+            // replacement-char garble on the client — issue #23).
             const keep = agentStreamKeep
             if len(rest) > keep {
-                content = append(content, rest[:len(rest)-keep])
-                in.offset = len(in.buffer) - keep
+                cut := len(rest) - keep
+                for cut > 0 && !utf8.RuneStart(rest[cut]) {
+                    cut--
+                }
+                if cut > 0 {
+                    content = append(content, rest[:cut])
+                    in.offset += cut
+                }
             }
             break
         }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
     "sync"
     "sync/atomic"
     "time"
+    "unicode/utf16"
     "unicode/utf8"
 
     _ "modernc.org/sqlite"
@@ -63,11 +64,14 @@ const (
     maxTokenRetries = 5
 
     // Z.AI direct config
-    BASE_URL           = "https://chat.z.ai"
     SALT_KEY           = "key-@@@@)))()((9))-xxxx&&&%%%%%"
     DEFAULT_FE_VERSION = "prod-fe-1.1.88"
     zaiUserAgent       = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
+
+// BASE_URL is a var (not const) only so tests can point the bridge at a
+// mock upstream; the default value is the production endpoint.
+var BASE_URL = "https://chat.z.ai"
 
 // ---------- Config struct (Z.AI) ----------
 
@@ -95,6 +99,13 @@ type Config struct {
         Format string
     }
     KnownModels []string
+    // StreamHoldback is the number of runes kept pending at the tail of the
+    // streamed content before it is forwarded to clients. Z.AI's stream is
+    // edit-based (edit_content can backtrack and rewrite the tail), and an
+    // append-only SSE client cannot take back text it already received.
+    // Holding back a small window lets ordinary trailing backtracks be
+    // absorbed invisibly. 0 disables the hold-back. See issue #23.
+    StreamHoldback int
 }
 
 func loadConfig() *Config {
@@ -110,6 +121,7 @@ func loadConfig() *Config {
     c.Logging.Level = "debug"
     c.Logging.Format = "text"
     c.KnownModels = []string{"GLM-5.1", "GLM-5"}
+    c.StreamHoldback = 24
 
     if p := os.Getenv("PORT"); p != "" {
         if n, err := strconv.Atoi(p); err == nil {
@@ -157,6 +169,11 @@ func loadConfig() *Config {
     }
     if f := os.Getenv("LOG_FORMAT"); f != "" {
         c.Logging.Format = f
+    }
+    if h := os.Getenv("STREAM_HOLDBACK"); h != "" {
+        if n, err := strconv.Atoi(h); err == nil && n >= 0 {
+            c.StreamHoldback = n
+        }
     }
     return c
 }
@@ -2163,14 +2180,160 @@ func statusFromError(errMsg string) int {
     }
 }
 
+// utf16IndexToByteIndex converts a UTF-16 code-unit offset — the indexing
+// semantics of JavaScript strings, used by the official Z.AI web frontend
+// (`content.substring(0, edit_index)`, see the prod-fe bundle) — into a
+// byte offset within s. It clamps at the end of s and never returns an
+// offset inside a multi-byte rune: an offset landing between the two
+// units of a surrogate pair is clamped to the start of that rune.
+func utf16IndexToByteIndex(s string, utf16Idx int) int {
+    if utf16Idx <= 0 {
+        return 0
+    }
+    byteIdx, units := 0, 0
+    for byteIdx < len(s) {
+        if units == utf16Idx {
+            return byteIdx
+        }
+        r, size := utf8.DecodeRuneInString(s[byteIdx:])
+        ru := utf16.RuneLen(r)
+        if ru < 0 {
+            ru = 1 // invalid byte: the JS frontend also sees one unit here
+        }
+        if units+ru > utf16Idx {
+            return byteIdx // inside a surrogate pair — clamp to rune start
+        }
+        units += ru
+        byteIdx += size
+    }
+    return len(s)
+}
+
+// commonPrefixLen returns the byte length of the longest common prefix of
+// a and b. The result is always on a rune boundary, so slicing either
+// string at that offset cannot produce invalid UTF-8.
+func commonPrefixLen(a, b string) int {
+    i := 0
+    for i < len(a) && i < len(b) {
+        ra, sa := utf8.DecodeRuneInString(a[i:])
+        rb, _ := utf8.DecodeRuneInString(b[i:])
+        if ra != rb {
+            break
+        }
+        i += sa
+    }
+    return i
+}
+
+// holdBackTail trims up to n runes from the end of s (rune-safe).
+func holdBackTail(s string, n int) string {
+    if n <= 0 || s == "" {
+        return s
+    }
+    i, count := len(s), 0
+    for i > 0 && count < n {
+        _, size := utf8.DecodeLastRuneInString(s[:i])
+        i -= size
+        count++
+    }
+    return s[:i]
+}
+
+// holdBackPartialDetailsTag trims a trailing fragment that could still be
+// the beginning of a <details> tag whose completion has not arrived yet,
+// so a tag streamed character by character never leaks to the client.
+// A COMPLETE "</details>" literal is kept (legitimate text); a complete
+// "<details" is held (waiting for its ">" to decide whether it is a tag).
+func holdBackPartialDetailsTag(s string) string {
+    i := strings.LastIndex(s, "<")
+    if i < 0 {
+        return s
+    }
+    suffix := s[i:]
+    if len(suffix) <= len("<details") && strings.HasPrefix("<details", suffix) {
+        return s[:i]
+    }
+    if len(suffix) < len("</details>") && strings.HasPrefix("</details>", suffix) {
+        return s[:i]
+    }
+    return s
+}
+
+// sseEmitter forwards snapshots of a growing (and occasionally rewritten)
+// text to an append-only consumer as rune-safe deltas. It tracks exactly
+// what the consumer has received so far and never emits a slice that
+// starts inside a multi-byte rune, so the consumer can never receive
+// invalid UTF-8 (which its JSON renderer would show as U+FFFD
+// replacement garble — the symptom reported in issue #23).
+type sseEmitter struct {
+    clientView string // exactly what the consumer has received so far
+}
+
+// delta returns the text to append to the consumer so it converges on
+// target as closely as possible, and updates the tracked view:
+//   - target extends the view   -> the new suffix (normal growth)
+//   - target is a prefix of the view (a deep edit truncated the text)
+//     -> "" — nothing can be taken back; the view is kept as-is so the
+//     following growth is not re-sent from a rewound base
+//   - target rewrote part of the view -> everything after the longest
+//     common prefix; the stale fragment in between stays on the consumer
+//     (unavoidable for append-only SSE, but it remains valid UTF-8)
+func (e *sseEmitter) delta(target string) string {
+    if target == e.clientView {
+        return ""
+    }
+    if strings.HasPrefix(target, e.clientView) {
+        delta := target[len(e.clientView):]
+        e.clientView = target
+        return delta
+    }
+    cp := commonPrefixLen(e.clientView, target)
+    if cp == len(target) {
+        return "" // consumer already has everything target contains
+    }
+    delta := target[cp:]
+    e.clientView += delta
+    return delta
+}
+
+// splitDetails extracts every complete <details ...>...</details> block
+// from raw: the block bodies (concatenated) become reasoning, everything
+// else becomes content. A trailing opener whose '>' has not arrived yet is
+// held pending (neither reasoning nor content) until more data arrives.
+func splitDetails(raw string) (reasoning, content string) {
+    var rb, cb strings.Builder
+    rest := raw
+    for {
+        idx := strings.Index(rest, "<details")
+        if idx < 0 {
+            cb.WriteString(rest)
+            break
+        }
+        cb.WriteString(rest[:idx])
+        tagEnd := strings.Index(rest[idx:], ">")
+        if tagEnd < 0 {
+            break // incomplete opener at the tail — hold pending
+        }
+        afterTag := rest[idx+tagEnd+1:]
+        closeIdx := strings.Index(afterTag, "</details>")
+        if closeIdx < 0 {
+            rb.WriteString(afterTag) // reasoning still streaming
+            break
+        }
+        rb.WriteString(afterTag[:closeIdx])
+        rest = afterTag[closeIdx+len("</details>"):]
+    }
+    return rb.String(), cb.String()
+}
+
 func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
     scanner := bufio.NewScanner(body)
     scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 
     // ── Accumulated state across SSE lines ──
-    var fullText strings.Builder
-    sentLen := 0
-    sentReasoning := 0
+    var fullText strings.Builder      // raw upstream content, verbatim
+    contentEmitter := &sseEmitter{}   // tracks what the client has received
+    reasoningEmitter := &sseEmitter{} // same for the reasoning channel
 
     // stripDetailsTags removes <details ...> and </details> wrappers
     // and leading "> " markdown-quote prefixes from each line.
@@ -2188,48 +2351,42 @@ func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
         return strings.TrimSpace(strings.Join(lines, "\n"))
     }
 
-    flush := func() {
+    // emitContent forwards the part of `target` the client has not seen
+    // yet. All slicing is rune-safe, so clients can never receive invalid
+    // UTF-8 (which their JSON renderer would show as U+FFFD replacement
+    // garble — the symptom reported in issue #23). FullText carries the
+    // authoritative upstream snapshot for non-stream consumers and for
+    // deep-edit re-sync detection in the handlers.
+    emitContent := func(target string) {
+        if delta := contentEmitter.delta(target); delta != "" {
+            ch <- ZAIResult{Chunk: delta, FullText: target}
+        }
+    }
+
+    flush := func(final bool) {
         raw := fullText.String()
 
         // Split <details ...> ... </details> into reasoning vs content
-        var reasoning, content string
-        if idx := strings.Index(raw, "<details"); idx >= 0 {
-            if tagEnd := strings.Index(raw[idx:], ">"); tagEnd >= 0 {
-                afterTag := raw[idx+tagEnd+1:]
-                if closeIdx := strings.Index(afterTag, "</details>"); closeIdx >= 0 {
-                    reasoning = afterTag[:closeIdx]
-                    content = raw[:idx] + afterTag[closeIdx+len("</details>"):]
-                } else {
-                    // <details> opened but not yet closed
-                    reasoning = afterTag
-                    content = raw[:idx]
-                }
-            } else {
-                content = raw // tag not complete yet
-            }
-        } else {
-            content = raw
-        }
-
+        reasoning, content := splitDetails(raw)
         if reasoning != "" {
             reasoning = stripDetailsTags(reasoning)
         }
 
-        // Emit content delta
-        if len(content) > sentLen {
-            ch <- ZAIResult{Chunk: content[sentLen:], FullText: content}
-            sentLen = len(content)
-        } else if len(content) < sentLen {
-            sentLen = len(content)
+        // Emit reasoning delta (prefix-aware, rune-safe)
+        if delta := reasoningEmitter.delta(reasoning); delta != "" {
+            ch <- ZAIResult{Reasoning: delta}
         }
 
-        // Emit reasoning delta
-        if len(reasoning) > sentReasoning {
-            ch <- ZAIResult{Reasoning: reasoning[sentReasoning:]}
-            sentReasoning = len(reasoning)
-        } else if len(reasoning) < sentReasoning {
-            sentReasoning = len(reasoning)
+        // While the stream is live, keep a small tail pending so ordinary
+        // trailing edit_content backtracks are absorbed invisibly, and
+        // never forward a fragment that could still grow into a <details>
+        // tag. The final flush releases everything.
+        target := content
+        if !final {
+            target = holdBackTail(target, config.StreamHoldback)
+            target = holdBackPartialDetailsTag(target)
         }
+        emitContent(target)
     }
 
     for scanner.Scan() {
@@ -2245,7 +2402,7 @@ func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
         }
         dataStr := trimmed[6:]
         if dataStr == "[DONE]" {
-            flush()
+            flush(true)
             return nil
         }
 
@@ -2267,59 +2424,41 @@ func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
 
         if data, ok := j["data"].(map[string]interface{}); ok {
             if phase, ok := data["phase"].(string); ok && phase == "done" {
-                flush()
+                flush(true)
                 return nil
             }
         }
 
         // ── Content accumulation ──
+        // Semantics mirror the official Z.AI web frontend (prod-fe bundle):
+        //   edit_content:  content = content.substring(0, edit_index) + edit_content
+        //                  where edit_index is a UTF-16 code-unit offset
+        //                  (JavaScript string indexing); a missing
+        //                  edit_index defaults to 0 (full replacement)
+        //   content:       full replacement of the accumulated text
+        //   delta_content: plain append
         if data, ok := j["data"].(map[string]interface{}); ok {
             if ec, ok := data["edit_content"].(string); ok && ec != "" {
-                // edit_content = FULL replacement starting at edit_index
-                editIndex := -1
+                editIndex := 0
                 if ei, ok := data["edit_index"].(float64); ok {
                     editIndex = int(ei)
                 }
                 current := fullText.String()
-                if editIndex >= 0 {
-                    // Convert rune-based edit_index to byte offset
-                    byteIdx := 0
-                    runeCount := 0
-                    for byteIdx < len(current) {
-                        if runeCount == editIndex {
-                            break
-                        }
-                        _, size := utf8.DecodeRuneInString(current[byteIdx:])
-                        byteIdx += size
-                        runeCount++
-                    }
-                    editIndex = byteIdx
-
-                    if editIndex <= len(current) {
-                        current = current[:editIndex] + ec
-                    } else {
-                        // Z.AI index beyond current length — pad
-                        for len(current) < editIndex {
-                            current += " "
-                        }
-                        current += ec
-                    }
-                } else {
-                    current += ec
-                }
+                byteIdx := utf16IndexToByteIndex(current, editIndex)
                 fullText.Reset()
-                fullText.WriteString(current)
+                fullText.WriteString(current[:byteIdx] + ec)
+            } else if tc, ok := data["content"].(string); ok && tc != "" {
+                fullText.Reset()
+                fullText.WriteString(tc)
             } else if dc, ok := data["delta_content"].(string); ok && dc != "" {
                 fullText.WriteString(dc)
-            } else if tc, ok := data["content"].(string); ok && tc != "" {
-                fullText.WriteString(tc)
             }
         }
 
-        flush()
+        flush(false)
     }
 
-    flush()
+    flush(true)
     return scanner.Err()
 }
 
@@ -2860,7 +2999,6 @@ func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOpti
     }
 
     fullContent := ""
-    sentContent := ""
 
     ch, err := sendToZAI(prompt, opts)
     if err != nil {
@@ -2900,24 +3038,24 @@ func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOpti
         }
 
         // Content delta
+        if result.FullText != "" && !strings.HasPrefix(result.FullText, fullContent) {
+            // A deep edit_content rewrite rewound text that was already
+            // forwarded: reset the stale agent interceptor (issue #23).
+            if interceptor != nil {
+                interceptor = newAgentInterceptor()
+            }
+        }
         if result.FullText != "" {
             fullContent = result.FullText
         } else {
             fullContent += result.Chunk
         }
 
-        if len(fullContent) < len(sentContent) {
-            sentContent = ""
-            if interceptor != nil {
-                interceptor = newAgentInterceptor()
-            }
-        }
-
-        if len(fullContent) <= len(sentContent) {
+        // The parser emits the exact rune-safe delta to forward.
+        delta := result.Chunk
+        if delta == "" {
             continue
         }
-        delta := fullContent[len(sentContent):]
-        sentContent = fullContent
 
         if interceptor != nil {
             contentDelta, toolCalls := interceptor.feed(delta)
@@ -3882,13 +4020,21 @@ func (a *agentStreamInterceptor) feed(chunk string) (contentDelta string, toolCa
         relIdx := strings.Index(data[a.flushed:], agentToolCallStart)
         if relIdx < 0 {
             // No start marker. Emit everything except a tail that could
-            // be a partial marker (len-1 chars held back).
+            // be a partial marker (len-1 chars held back). The cut is
+            // pulled back to a rune boundary so a multi-byte character
+            // is never split across emissions (invalid UTF-8 would render
+            // as replacement-char garble on the client — issue #23).
             safe := len(data) - a.flushed
             tail := len(agentToolCallStart) - 1
             if safe > tail {
                 emit := safe - tail
-                contentDelta += data[a.flushed : a.flushed+emit]
-                a.flushed += emit
+                for emit > 0 && !utf8.RuneStart(data[a.flushed+emit]) {
+                    emit--
+                }
+                if emit > 0 {
+                    contentDelta += data[a.flushed : a.flushed+emit]
+                    a.flushed += emit
+                }
             }
             return
         }
@@ -4109,7 +4255,6 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
         writeSSE(toJSON(initChunk))
 
         fullContent := ""
-        sentContent := ""
         fullReasoning := ""
 
         var interceptor agentInterceptor
@@ -4188,25 +4333,25 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
                     writeSSE(toJSON(rChunk))
                     continue
                 }
+                if result.FullText != "" && !strings.HasPrefix(result.FullText, fullContent) {
+                    // A deep edit_content rewrite rewound text that was
+                    // already forwarded: the agent interceptor's view of
+                    // the stream is stale, reset it (issue #23).
+                    if interceptor != nil {
+                        interceptor = newAgentInterceptor()
+                    }
+                }
                 if result.FullText != "" {
                     fullContent = result.FullText
                 } else {
                     fullContent += result.Chunk
                 }
-                
-                // Detect content shrinkage (e.g., edit_content truncated the text)
-                if len(fullContent) < len(sentContent) {
-                    sentContent = ""
-                    if interceptor != nil {
-                        interceptor = newAgentInterceptor()
-                    }
-                }
-                
-                if len(fullContent) <= len(sentContent) {
+
+                // The parser emits the exact rune-safe delta to forward.
+                delta := result.Chunk
+                if delta == "" {
                     continue
                 }
-                delta := fullContent[len(sentContent):]
-                sentContent = fullContent
 
                 if interceptor != nil {
                     contentDelta, toolCalls := interceptor.feed(delta)

--- a/sse_garble_test.go
+++ b/sse_garble_test.go
@@ -1,0 +1,552 @@
+// sse_garble_test.go
+//
+// Reproduction + regression tests for issue #23 (输出乱码的问题):
+// garbled / unreadable characters interspersed in streamed output.
+//
+// Root causes proven here (all verified against the official Z.AI web
+// frontend, prod-fe bundle):
+//
+//  1. edit_index is a UTF-16 code-unit offset — the frontend applies
+//     `content.substring(0, edit_index) + edit_content` (JavaScript string
+//     indexing). The old parser treated it as a rune count, splicing at
+//     the wrong position whenever non-BMP characters (emoji, CJK ext-B)
+//     were present.
+//  2. The `content` SSE field is a FULL replacement (frontend:
+//     `lt.content = rr`); the old parser appended it, duplicating text.
+//  3. The old parser diffed accumulated text by BYTE LENGTH and sliced
+//     `content[sentLen:]`. After any edit that changed the byte length —
+//     or a <details> tag streamed character by character — the slice
+//     landed inside a multi-byte rune, emitting invalid UTF-8 that JSON
+//     renderers display as U+FFFD replacement garble (the reported
+//     "无法查看的乱码"). Partial "<det" tag fragments also leaked.
+//
+// The tests feed synthetic Z.AI SSE streams (shaped exactly like the
+// documented upstream protocol) through the REAL streamSSEResponse
+// parser, then replay the emitted ZAIResults through the exact logic of
+// chatCompletionsHandler / anthropicStreamResponse, and assert what an
+// OpenAI-compatible client actually receives.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// sseEvent wraps one upstream payload as an SSE `data:` line.
+func sseEvent(payload string) string {
+	return "data: " + payload + "\n\n"
+}
+
+// runSSEParser runs the real streamSSEResponse over a synthetic body and
+// collects every ZAIResult the channel receives.
+func runSSEParser(t *testing.T, body string) []ZAIResult {
+	t.Helper()
+	ch := make(chan ZAIResult, 4096)
+	errCh := make(chan error, 1)
+	go func() {
+		// sendToZAI closes the channel after sendToZAIStream returns;
+		// mirror that here so the drain loop terminates.
+		errCh <- streamSSEResponse(strings.NewReader(body), ch)
+		close(ch)
+	}()
+	var results []ZAIResult
+	for r := range ch {
+		results = append(results, r)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("streamSSEResponse returned error: %v", err)
+	}
+	return results
+}
+
+// replayClientView replicates VERBATIM the accumulation logic of
+// chatCompletionsHandler / anthropicStreamResponse after the issue #23
+// fix: the parser owns diffing, the handler forwards result.Chunk and
+// tracks the result.FullText snapshot.
+func replayClientView(results []ZAIResult) (clientText string, deltas []string) {
+	fullContent := ""
+	for _, result := range results {
+		if result.Reasoning != "" {
+			continue // reasoning travels on its own channel
+		}
+		if result.FullText != "" {
+			fullContent = result.FullText
+		} else {
+			fullContent += result.Chunk
+		}
+		delta := result.Chunk
+		if delta == "" {
+			continue
+		}
+		deltas = append(deltas, delta)
+	}
+	return strings.Join(deltas, ""), deltas
+}
+
+// assertValidUTF8 fails the test if any client-visible delta contains
+// invalid UTF-8 (which json.Marshal would replace with U+FFFD — the
+// garbled characters reported in issue #23).
+func assertValidUTF8(t *testing.T, deltas []string) {
+	t.Helper()
+	for i, d := range deltas {
+		if !utf8.ValidString(d) {
+			t.Errorf("client delta #%d is INVALID UTF-8 (renders as replacement-char garble): %q", i, d)
+		}
+	}
+}
+
+// withHoldback runs fn with a temporary StreamHoldback value.
+func withHoldback(t *testing.T, n int, fn func()) {
+	t.Helper()
+	old := config.StreamHoldback
+	config.StreamHoldback = n
+	defer func() { config.StreamHoldback = old }()
+	fn()
+}
+
+// ── Baseline: pure delta_content append must stay clean ─────────────────────
+
+func TestSSEBaselinePureDeltaAppend(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"你好，"}}`) +
+		sseEvent(`{"data":{"delta_content":"世界 🙂"}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	for _, hb := range []int{0, 24} {
+		withHoldback(t, hb, func() {
+			results := runSSEParser(t, body)
+			clientText, deltas := replayClientView(results)
+			assertValidUTF8(t, deltas)
+			if clientText != "你好，世界 🙂" {
+				t.Errorf("holdback=%d: client text = %q, want %q", hb, clientText, "你好，世界 🙂")
+			}
+		})
+	}
+}
+
+// ── Issue #23 core repro: edit_content revision garbled the output ──────────
+//
+// Upstream streams "Hello 你好", then revises via edit_content from UTF-16
+// index 6 to "世界！". With hold-back disabled (worst case: the rewrite
+// touches text already forwarded to the client) the client must still
+// receive only valid UTF-8 — the old code sliced mid-rune here and
+// emitted raw continuation bytes.
+
+func TestSSEEditContentRevisionNeverEmitsGarble(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"Hello 你好"}}`) +
+		sseEvent(`{"data":{"edit_content":"世界！","edit_index":6}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	withHoldback(t, 0, func() {
+		results := runSSEParser(t, body)
+		clientText, deltas := replayClientView(results)
+		assertValidUTF8(t, deltas)
+		// The stale "你好" cannot be taken back from an append-only
+		// client, but the corrected tail must follow it intact.
+		if !strings.HasSuffix(clientText, "世界！") {
+			t.Errorf("client text = %q, must end with the corrected tail %q", clientText, "世界！")
+		}
+	})
+}
+
+// With the default hold-back window the tail revision happens inside the
+// pending region, so the client must converge EXACTLY on the upstream's
+// final text — no stale fragment, no garble.
+func TestSSEEditContentRevisionAbsorbedByHoldback(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"Hello 你好"}}`) +
+		sseEvent(`{"data":{"edit_content":"世界！","edit_index":6}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	withHoldback(t, 24, func() {
+		results := runSSEParser(t, body)
+		clientText, deltas := replayClientView(results)
+		assertValidUTF8(t, deltas)
+		want := "Hello 世界！"
+		if clientText != want {
+			t.Errorf("client text = %q, want %q", clientText, want)
+		}
+	})
+}
+
+// ── Deep edit far beyond the hold-back window must stay readable ────────────
+
+func TestSSEDeepEditStaysValidUTF8(t *testing.T) {
+	// 30 runes of Chinese (90 bytes), then the model backtracks to rune 2
+	// and retypes a LONGER passage (ASCII + Chinese mix, as real output
+	// contains markdown/spaces). The old byte-length diff sliced the new
+	// content at the old byte offset — inside a multi-byte rune.
+	longPrefix := strings.Repeat("长", 30)
+	body := sseEvent(fmt.Sprintf(`{"data":{"delta_content":"%s"}}`, longPrefix)) +
+		sseEvent(`{"data":{"edit_content":"短文abc` + longPrefix + `","edit_index":2}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	withHoldback(t, 0, func() {
+		results := runSSEParser(t, body)
+		_, deltas := replayClientView(results)
+		assertValidUTF8(t, deltas)
+	})
+}
+
+// ── <details> reasoning tag split across SSE events ─────────────────────────
+//
+// The upstream streams the "<details" opener one fragment at a time. The
+// old parser emitted the partial "<det" fragment as content, then sliced
+// mid-rune when the tag completed and content shrank back — the exact
+// "穿插着一些无法查看的乱码" pattern from the issue report.
+
+func TestSSEDetailsTagSplitAcrossEvents(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"答案"}}`) +
+		sseEvent(`{"data":{"delta_content":"<det"}}`) +
+		sseEvent(`{"data":{"delta_content":"ails>思考过程</details>"}}`) +
+		sseEvent(`{"data":{"delta_content":"正文内容"}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	for _, hb := range []int{0, 24} {
+		withHoldback(t, hb, func() {
+			results := runSSEParser(t, body)
+			clientText, deltas := replayClientView(results)
+
+			assertValidUTF8(t, deltas)
+			if strings.Contains(clientText, "<det") || strings.Contains(clientText, "<details") {
+				t.Errorf("holdback=%d: <details> tag fragment leaked into client content: %q", hb, clientText)
+			}
+			want := "答案正文内容"
+			if clientText != want {
+				t.Errorf("holdback=%d: client text = %q, want %q", hb, clientText, want)
+			}
+
+			// Reasoning must still arrive intact on the reasoning channel.
+			reasoning := ""
+			for _, r := range results {
+				reasoning += r.Reasoning
+			}
+			if reasoning != "思考过程" {
+				t.Errorf("holdback=%d: reasoning = %q, want %q", hb, reasoning, "思考过程")
+			}
+		})
+	}
+}
+
+// ── edit_index is UTF-16, not runes (owner's hypothesis, confirmed) ─────────
+//
+// The official frontend does content.substring(0, edit_index) — UTF-16
+// code units. "A🙂" is 2 runes but 3 UTF-16 units; an edit right after
+// the emoji arrives with edit_index=3. The old rune-based conversion
+// spliced one character too late and silently corrupted the text.
+
+func TestSSEEditIndexIsUTF16Units(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"A🙂B"}}`) +
+		// UTF-16 index 3 = after "A" (1 unit) + "🙂" (2 units)
+		sseEvent(`{"data":{"edit_content":"C","edit_index":3}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	// Hold-back absorbs the tail rewrite, so the client must converge
+	// exactly. Under the old rune-based conversion edit_index=3 spliced
+	// AFTER the "B" (3 runes), appending instead of replacing — the
+	// client would have seen "A🙂BC".
+	withHoldback(t, 24, func() {
+		results := runSSEParser(t, body)
+		clientText, deltas := replayClientView(results)
+		assertValidUTF8(t, deltas)
+		want := "A🙂C"
+		if clientText != want {
+			t.Errorf("client text = %q, want %q (edit_index must be interpreted as UTF-16 units)", clientText, want)
+		}
+	})
+}
+
+// Pure-BMP text: UTF-16 units == runes, must keep working.
+func TestSSEEditIndexBMPText(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"你好世界"}}`) +
+		sseEvent(`{"data":{"edit_content":"地球","edit_index":2}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	// Hold-back absorbs the tail rewrite: the client must converge exactly.
+	withHoldback(t, 24, func() {
+		results := runSSEParser(t, body)
+		clientText, deltas := replayClientView(results)
+		assertValidUTF8(t, deltas)
+		want := "你好地球"
+		if clientText != want {
+			t.Errorf("client text = %q, want %q", clientText, want)
+		}
+	})
+}
+
+// ── `content` events are full replacements, not appends ─────────────────────
+//
+// Official frontend: `lt.content = rr` ("全量更新"). The old parser
+// appended `content` events, duplicating the whole message whenever the
+// upstream sent a snapshot.
+
+func TestSSEContentFieldIsFullReplacement(t *testing.T) {
+	body := sseEvent(`{"data":{"delta_content":"partial text"}}`) +
+		sseEvent(`{"data":{"content":"完整的最终文本"}}`) +
+		sseEvent(`{"data":{"phase":"done"}}`) +
+		"data: [DONE]\n\n"
+
+	// Hold-back keeps "partial text" pending, so the replacement happens
+	// before anything reaches the client: it must see ONLY the snapshot.
+	// (The old parser APPENDED the snapshot, duplicating everything.)
+	withHoldback(t, 24, func() {
+		results := runSSEParser(t, body)
+		clientText, deltas := replayClientView(results)
+		assertValidUTF8(t, deltas)
+		if strings.Contains(clientText, "partial text") {
+			t.Errorf("content snapshot must REPLACE, client text = %q", clientText)
+		}
+		if !strings.HasSuffix(clientText, "完整的最终文本") {
+			t.Errorf("client text = %q, must end with the snapshot", clientText)
+		}
+	})
+}
+
+// ── Long stream with interleaved edits: parser contract holds ───────────────
+//
+// A realistic-length stream (well past the hold-back window) with mixed
+// Chinese/ASCII/emoji and periodic tail edits. Every chunk reaching the
+// client must be valid UTF-8, FullText snapshots must equal the running
+// concatenation of chunks, and the final text must match upstream.
+
+func TestSSELongStreamWithTailEditsContract(t *testing.T) {
+	var b strings.Builder
+	// 40 events of mixed text, then a tail edit inside the hold-back zone.
+	for i := 0; i < 40; i++ {
+		b.WriteString(sseEvent(fmt.Sprintf(`{"data":{"delta_content":"第%d段。"}}`, i)))
+	}
+	// Tail backtrack: replace the last two events' text (within the 24-rune
+	// hold-back zone). Segments 0-9 are 4 runes, 10-37 are 5 runes each:
+	// 10×4 + 28×5 = 180 UTF-16 units before segments 38-39.
+	b.WriteString(sseEvent(`{"data":{"edit_content":"最终段。","edit_index":180}}`))
+	b.WriteString(sseEvent(`{"data":{"delta_content":"收尾 🙂"}}`))
+	b.WriteString(sseEvent(`{"data":{"phase":"done"}}`))
+	b.WriteString("data: [DONE]\n\n")
+
+	withHoldback(t, 24, func() {
+		results := runSSEParser(t, b.String())
+		clientText, deltas := replayClientView(results)
+
+		assertValidUTF8(t, deltas)
+
+		// Parser contract: every emitted chunk must be a suffix of its
+		// FullText snapshot (never a mid-string slice), and the final
+		// snapshot must equal the upstream's final content.
+		for i, r := range results {
+			if r.Reasoning != "" || r.Chunk == "" {
+				continue
+			}
+			if !strings.HasSuffix(r.FullText, r.Chunk) {
+				t.Fatalf("result #%d: chunk %q is not a suffix of snapshot %q", i, r.Chunk, r.FullText)
+			}
+		}
+		last := ""
+		for _, r := range results {
+			if r.FullText != "" {
+				last = r.FullText
+			}
+		}
+
+		want := strings.Builder{}
+		for i := 0; i < 38; i++ {
+			want.WriteString(fmt.Sprintf("第%d段。", i))
+		}
+		want.WriteString("最终段。收尾 🙂")
+		if last != want.String() {
+			t.Errorf("final snapshot = %q, want %q", last, want.String())
+		}
+		if clientText != want.String() {
+			t.Errorf("client text = %q, want %q", clientText, want.String())
+		}
+	})
+}
+
+// ── Unit tests for the helper functions ─────────────────────────────────────
+
+func TestUTF16IndexToByteIndex(t *testing.T) {
+	cases := []struct {
+		s    string
+		idx  int
+		want int
+	}{
+		{"", 5, 0},                // empty string
+		{"abc", 0, 0},             // zero
+		{"abc", -3, 0},            // negative
+		{"abc", 2, 2},             // ASCII
+		{"abc", 99, 3},            // beyond end -> clamp
+		{"你好", 1, 3},            // BMP Chinese: 1 unit = 1 rune = 3 bytes
+		{"你好", 2, 6},            // end
+		{"A🙂B", 0, 0},            // before emoji
+		{"A🙂B", 1, 1},            // after 'A'
+		{"A🙂B", 2, 1},            // inside the surrogate pair -> clamp to rune start
+		{"A🙂B", 3, 5},            // after the emoji (1 + 4 bytes)
+		{"A🙂B", 4, 6},            // after 'B'
+		{"A🙂B", 100, 6},          // beyond end
+		{"你好🙂世界", 4, 10},     // 2+2 units then emoji: bytes 6+4=10
+	}
+	for _, c := range cases {
+		if got := utf16IndexToByteIndex(c.s, c.idx); got != c.want {
+			t.Errorf("utf16IndexToByteIndex(%q, %d) = %d, want %d", c.s, c.idx, got, c.want)
+		}
+		// The result must always be a rune boundary.
+		got := utf16IndexToByteIndex(c.s, c.idx)
+		if got < len(c.s) && !utf8.RuneStart(c.s[got]) {
+			t.Errorf("utf16IndexToByteIndex(%q, %d) = %d lands mid-rune", c.s, c.idx, got)
+		}
+	}
+}
+
+func TestCommonPrefixLenRuneSafe(t *testing.T) {
+	cases := []struct{ a, b string; want int }{
+		{"", "", 0},
+		{"abc", "abd", 2},
+		{"你好世界", "你好地球", 6},
+		{"A🙂B", "A🙂C", 5},
+		{"abc", "abc", 3},
+		{"abc", "xabc", 0},
+	}
+	for _, c := range cases {
+		if got := commonPrefixLen(c.a, c.b); got != c.want {
+			t.Errorf("commonPrefixLen(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestSSEEmitterDelta(t *testing.T) {
+	// Normal growth.
+	e := &sseEmitter{}
+	if got := e.delta("abc"); got != "abc" {
+		t.Errorf("growth from empty: got %q, want %q", got, "abc")
+	}
+	if got := e.delta("abcdef"); got != "def" {
+		t.Errorf("growth: got %q, want %q", got, "def")
+	}
+	if got := e.delta("abcdef"); got != "" {
+		t.Errorf("no-op: got %q, want empty", got)
+	}
+
+	// Multibyte growth stays rune-aligned.
+	e2 := &sseEmitter{}
+	if got := e2.delta("你好"); got != "你好" {
+		t.Errorf("multibyte growth: got %q", got)
+	}
+	if got := e2.delta("你好世界"); got != "世界" {
+		t.Errorf("multibyte growth delta: got %q, want %q", got, "世界")
+	}
+
+	// Deep truncation: target is a prefix of the client view — nothing is
+	// sent and the view is NOT rewound, so the following growth does not
+	// re-emit text the client already has.
+	e3 := &sseEmitter{}
+	e3.delta("你好世界天地")
+	if got := e3.delta("你好世界"); got != "" {
+		t.Errorf("shrink must emit nothing, got %q", got)
+	}
+	if got := e3.delta("你好世界天地人"); got != "人" {
+		t.Errorf("growth after shrink: got %q, want %q", got, "人")
+	}
+
+	// Rewrite inside the view: re-sync from the common prefix, valid UTF-8.
+	e4 := &sseEmitter{}
+	e4.delta("Hello 你好")
+	got := e4.delta("Hello 世界！")
+	if got != "世界！" {
+		t.Errorf("rewrite re-sync: got %q, want %q", got, "世界！")
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("rewrite re-sync produced invalid UTF-8: %q", got)
+	}
+
+	// Full rewrite.
+	e5 := &sseEmitter{}
+	e5.delta("abc")
+	if got := e5.delta("xyz"); got != "xyz" {
+		t.Errorf("full rewrite: got %q, want %q", got, "xyz")
+	}
+}
+
+func TestHoldBackTail(t *testing.T) {
+	cases := []struct {
+		s    string
+		n    int
+		want string
+	}{
+		{"", 5, ""},
+		{"abc", 0, "abc"},
+		{"abc", 2, "a"},
+		{"abc", 99, ""},
+		{"你好世界", 2, "你好"},
+		{"A🙂B", 1, "A🙂"},
+		{"A🙂B", 2, "A"},
+	}
+	for _, c := range cases {
+		got := holdBackTail(c.s, c.n)
+		if got != c.want {
+			t.Errorf("holdBackTail(%q, %d) = %q, want %q", c.s, c.n, got, c.want)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("holdBackTail(%q, %d) produced invalid UTF-8: %q", c.s, c.n, got)
+		}
+	}
+}
+
+func TestHoldBackPartialDetailsTag(t *testing.T) {
+	cases := []struct{ s, want string }{
+		{"abc", "abc"},
+		{"abc<", "abc"},
+		{"abc<d", "abc"},
+		{"abc<det", "abc"},
+		{"abc<details", "abc"},               // complete opener literal held
+		{"abc</det", "abc"},
+		{"abc</details>", "abc</details>"},   // complete close tag stays (literal text)
+		{"abc<details>", "abc<details>"},     // splitDetails owns complete openers; not this layer
+		{"abc<div>", "abc<div>"},             // unrelated tag stays
+		{"abc<details> x", "abc<details> x"}, // opener already followed by more text stays
+	}
+	for _, c := range cases {
+		if got := holdBackPartialDetailsTag(c.s); got != c.want {
+			t.Errorf("holdBackPartialDetailsTag(%q) = %q, want %q", c.s, got, c.want)
+		}
+	}
+}
+
+func TestSplitDetails(t *testing.T) {
+	cases := []struct {
+		raw        string
+		wantReason string
+		wantContent string
+	}{
+		{"plain text", "", "plain text"},
+		{"<details>think</details>answer", "think", "answer"},
+		{"before<details>think</details>after", "think", "beforeafter"},
+		// A partial tag FRAGMENT ("<det") passes through splitDetails —
+		// it is held back at the emission layer (holdBackPartialDetailsTag)
+		// while streaming and only released as literal text by the final
+		// flush if the stream really ends there.
+		{"answer<det", "", "answer<det"},
+		// Complete opener literal without '>' yet: held pending entirely.
+		{"answer<details", "", "answer"},
+		{"answer<details sty", "", "answer"},
+		// opener complete, reasoning still streaming
+		{"a<details>thinking so far", "thinking so far", "a"},
+		// multiple blocks
+		{"<details>t1</details>x<details>t2</details>y", "t1t2", "xy"},
+		// attributes on the opener
+		{"<details type=\"thinking\">t</details>ans", "t", "ans"},
+	}
+	for _, c := range cases {
+		r, content := splitDetails(c.raw)
+		if r != c.wantReason || content != c.wantContent {
+			t.Errorf("splitDetails(%q) = (%q, %q), want (%q, %q)",
+				c.raw, r, content, c.wantReason, c.wantContent)
+		}
+	}
+}

--- a/sse_http_integration_test.go
+++ b/sse_http_integration_test.go
@@ -1,0 +1,163 @@
+// sse_http_integration_test.go
+//
+// End-to-end regression test for issue #23 through the REAL HTTP stack:
+// chatCompletionsHandler -> sendToZAI -> sendToZAIStream ->
+// streamSSEResponse -> OpenAI SSE chunks written to the wire.
+//
+// Only the Z.AI upstream is mocked (httptest); captcha is bypassed via
+// the agent-mode captcha cache (pre-seeded), and BASE_URL points at the
+// mock. The mock stream contains every pathological shape from the issue
+// report: multibyte Chinese text, an edit_content tail revision, and a
+// <details> reasoning tag streamed character by character.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func TestHTTPEndToEndGarbleFix(t *testing.T) {
+	longPrefix := strings.Repeat("长", 30)
+
+	// ── Mock Z.AI upstream ────────────────────────────────────────────────
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		events := []string{
+			fmt.Sprintf(`{"data":{"delta_content":"%s"}}`, longPrefix),
+			`{"data":{"delta_content":"<det"}}`,
+			`{"data":{"delta_content":"ails>让我想想。</details>"}}`,
+			`{"data":{"delta_content":"答案是："}}`,
+			`{"data":{"delta_content":"42。"}}`,
+			// Tail revision: replace "42。". edit_index counts the RAW
+			// accumulated text (frontend: lt.content.substring(0, i)),
+			// which INCLUDES the <details> block:
+			//   30 (长×30) + 9 ("<details>") + 5 ("让我想想。")
+			//   + 10 ("</details>") + 4 ("答案是：") = 58
+			`{"data":{"edit_content":"四十二！","edit_index":58}}`,
+			`{"data":{"delta_content":" 🙂"}}`,
+			`{"data":{"phase":"done"}}`,
+		}
+		for _, e := range events {
+			fmt.Fprintf(w, "data: %s\n\n", e)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	// ── Point the bridge at the mock ──────────────────────────────────────
+	oldBase := BASE_URL
+	BASE_URL = upstream.URL
+	defer func() { BASE_URL = oldBase }()
+
+	// ── Pre-seed session (skip real guest auth) ───────────────────────────
+	session.mu.Lock()
+	oldToken, oldUser, oldInit := session.Token, session.UserID, session.Initialized
+	session.Token = "test-token"
+	session.UserID = "test-user"
+	session.Initialized = true
+	session.mu.Unlock()
+	defer func() {
+		session.mu.Lock()
+		session.Token, session.UserID, session.Initialized = oldToken, oldUser, oldInit
+		session.mu.Unlock()
+	}()
+
+	// ── Bypass captcha via the agent-mode cache ───────────────────────────
+	oldAgentMode, oldHoldback := config.AgentMode, config.StreamHoldback
+	config.AgentMode = true
+	config.StreamHoldback = 24
+	defer func() { config.AgentMode, config.StreamHoldback = oldAgentMode, oldHoldback }()
+
+	captchaCache.mu.Lock()
+	captchaCache.params = append(captchaCache.params, cachedCaptcha{
+		value:       "test-captcha-param",
+		generatedAt: time.Now(),
+	})
+	captchaCache.mu.Unlock()
+
+	// ── Drive the real handler ────────────────────────────────────────────
+	body := `{"model":"glm-4.7","stream":true,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	chatCompletionsHandler(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// ── Parse the OpenAI SSE the client received over the wire ────────────
+	clientText := ""
+	reasoning := ""
+	contentChunks := 0
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
+			continue
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"delta"`
+			} `json:"choices"`
+			Error *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line[6:]), &chunk); err != nil {
+			continue
+		}
+		if chunk.Error != nil {
+			t.Fatalf("client received error chunk: %s", chunk.Error.Message)
+		}
+		for _, ch := range chunk.Choices {
+			if ch.Delta.Content != "" {
+				if !utf8.ValidString(ch.Delta.Content) {
+					t.Errorf("client received INVALID UTF-8 content delta (renders as garble): %q", ch.Delta.Content)
+				}
+				clientText += ch.Delta.Content
+				contentChunks++
+			}
+			if ch.Delta.ReasoningContent != "" {
+				if !utf8.ValidString(ch.Delta.ReasoningContent) {
+					t.Errorf("client received INVALID UTF-8 reasoning delta: %q", ch.Delta.ReasoningContent)
+				}
+				reasoning += ch.Delta.ReasoningContent
+			}
+		}
+	}
+
+	if strings.Contains(clientText, "<det") || strings.Contains(clientText, "<details") {
+		t.Errorf("<details> tag fragment leaked into client output: %q", clientText)
+	}
+	if contentChunks < 2 {
+		t.Errorf("expected the response to stream in multiple chunks, got %d", contentChunks)
+	}
+	want := longPrefix + "答案是：四十二！ 🙂"
+	if clientText != want {
+		t.Errorf("client text = %q, want %q", clientText, want)
+	}
+	if reasoning != "让我想想。" {
+		t.Errorf("reasoning = %q, want %q", reasoning, "让我想想。")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #23 (输出乱码的问题 — garbled/unreadable characters interspersed in streamed output).

This was reproduced locally with failing tests **before** any fix, and the root causes were verified against the official Z.AI web frontend (`prod-fe-1.1.91` bundle). The repo owner's hypothesis in the issue ("the API uses UTF‑16 but main.go uses UTF‑8") turned out to be correct.

## Root causes

1. **`edit_index` is a UTF‑16 code‑unit offset, not a rune count.** The official frontend applies `content.substring(0, edit_index) + edit_content` (JavaScript string indexing). The old rune‑based conversion spliced at the wrong position whenever non‑BMP characters (emoji, CJK ext‑B) were present.
2. **The `content` SSE field is a FULL replacement** (frontend: `lt.content = rr`, "全量更新"); the parser **appended** it, duplicating text whenever the upstream sent a snapshot.
3. **Byte‑length diffing sliced mid‑rune.** The parser diffed by byte length and sliced `content[sentLen:]`. After any edit that changed the byte length — or a `<details>` tag streamed character‑by‑character — the slice landed inside a multi‑byte rune, emitting **invalid UTF‑8** that clients render as `U+FFFD` replacement garble. Partial `<det` tag fragments also leaked into content.
4. **Both agent‑mode interceptors** (modern + legacy) held back their marker window by raw byte count, splitting multi‑byte runes across emissions.

## What changed

- `streamSSEResponse` rewritten around a rune‑safe, prefix‑aware emitter (`sseEmitter`) that tracks exactly what the client has received — deltas can never start inside a multi‑byte rune.
- `utf16IndexToByteIndex()` converts `edit_index` with JavaScript semantics (surrogate‑pair aware, clamped, never mid‑rune).
- `splitDetails()` handles multiple `<details>` blocks and holds an incomplete trailing opener pending; `holdBackPartialDetailsTag()` stops char‑by‑char streamed tags from leaking.
- `STREAM_HOLDBACK` (default `24` runes, `0` disables) keeps a small tail pending so ordinary trailing `edit_content` backtracks are absorbed invisibly; deep edits re‑sync from the longest common prefix and stay valid UTF‑8.
- OpenAI + Anthropic stream handlers forward the parser's exact deltas; agent interceptors reset only on genuine deep rewrites.
- Agent interceptor hold‑back cuts pulled back to rune boundaries.
- `BASE_URL` made a `var` (same default) purely so tests can point the bridge at a mock upstream.

## Validation

- **17 new tests**: `sse_garble_test.go` (unit/contract, incl. UTF‑16 index, full‑replacement, tag‑split, deep‑edit, long‑stream) + `sse_http_integration_test.go` (end‑to‑end through the real `chatCompletionsHandler` against a mocked Z.AI upstream).
- The garble repro tests **fail on the old code** (capturing raw invalid‑UTF‑8 deltas like `"\x96\x87内容"` and `<det` leaks) and **pass with the fix**.
- All **45 tests pass** (28 pre‑existing + 17 new); `go vet` clean; server boots and connects to Z.AI.
- Note: `go test -race` aborts on this ARM64 host with `ThreadSanitizer: unsupported VMA range` (kernel/TSan incompatibility, unrelated to the change).

## Behavior notes

- Append‑only SSE clients cannot "take back" text already delivered. With the default hold‑back, ordinary tail backtracks are fully absorbed (client converges exactly on the upstream's final text). A deep rewrite that reaches before the already‑forwarded region now re‑syncs from the common prefix — readable and valid UTF‑8, instead of garble.
- No change for pure `delta_content` streams beyond a ≤24‑rune tail latency during streaming (final text is identical and complete).
