### PR TITLE
fix(agent): parse Zhipu's native <tool_call> syntax

### DIFF
--- a/internal/zbridge/agent.go
+++ b/internal/zbridge/agent.go
@@ -670,6 +670,10 @@ const agentStreamKeep = agentWorstMarkerLen + len("```json\n") + 5
 // NormalizeAgentFences removes fence lines adjacent to tool-call markers from
 // finished text (non-streaming path).
 func NormalizeAgentFences(text string) string {
+    // Zhipu models sometimes emit their native <tool_call>/<arg_key> syntax
+    // instead of the marker form the prompt asks for; fold it in first so the
+    // rest of the pipeline sees a single shape.
+    text = TranslateNativeToolCalls(text)
     for {
         t := agentFenceAfterEndRe.ReplaceAllString(text, "${1}${2}")
         t = agentFenceBeforeCallRe.ReplaceAllString(t, "$1")
@@ -1177,6 +1181,14 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
 
         rest := in.buffer[in.offset:]
         start, markerLen := findAgentMarker(rest, agentStartWord, final)
+        // Zhipu's native <tool_call> syntax streams as plain text and would
+        // otherwise reach the client verbatim.
+        if handled, done := in.drainNativeBlock(rest, start, final, &content, &toolCalls); handled {
+            if done {
+                continue
+            }
+            break
+        }
         if start < 0 {
             if final {
                 // End of data: everything left is ordinary content.

--- a/internal/zbridge/agent_native.go
+++ b/internal/zbridge/agent_native.go
@@ -1,0 +1,136 @@
+package zbridge
+
+import (
+    "encoding/json"
+    "regexp"
+    "strings"
+)
+
+// Zhipu's own models fall back to the tool-call syntax they were trained on
+// instead of the <<<TOOL_CALL>>>{json}<<<END_TOOL_CALL>>> shape the agent
+// prompt asks for:
+//
+//	<tool_call>bash
+//	<arg_key>command</arg_key>
+//	<arg_value>ls -la</arg_value>
+//	</tool_call>
+//
+// Nothing downstream recognises it, so the block reaches the client verbatim
+// as assistant text — the model looks like it narrated a tool call instead of
+// making one. Worse, once that text is in the transcript the model imitates
+// its own broken output, so a single slip poisons the rest of the session.
+//
+// Translating the block into the canonical marker form lets the existing
+// parser, streaming interceptor and strip pass handle it unchanged.
+
+var nativeToolCallRe = regexp.MustCompile(`(?s)<tool_call>\s*([A-Za-z0-9_.\-]+)\s*(.*?)</tool_call>`)
+
+var nativeArgPairRe = regexp.MustCompile(`(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>`)
+
+// HasNativeToolCall reports whether s contains a complete native block.
+func HasNativeToolCall(s string) bool {
+    return nativeToolCallRe.MatchString(s)
+}
+
+// nativeToolCallPrefix reports whether s ends inside what could still grow
+// into a native tool-call block, so a streaming caller knows to hold the tail
+// back instead of leaking half a block to the client.
+func nativeToolCallPrefix(s string) bool {
+    idx := strings.LastIndex(s, "<tool_call>")
+    if idx < 0 {
+        // A bare "<tool_c…" tail may still complete on the next chunk.
+        for k := 1; k < len(nativeToolOpen) && k <= len(s); k++ {
+            if strings.HasSuffix(s, nativeToolOpen[:k]) {
+                return true
+            }
+        }
+        return false
+    }
+    return !strings.Contains(s[idx:], "</tool_call>")
+}
+
+const nativeToolOpen = "<tool_call>"
+const nativeToolClose = "</tool_call>"
+
+// TranslateNativeToolCalls rewrites every complete native block into the
+// canonical marker form. Text outside such blocks is returned untouched, and
+// input without a native block is returned unchanged.
+func TranslateNativeToolCalls(text string) string {
+    if !strings.Contains(text, nativeToolOpen) {
+        return text
+    }
+    return nativeToolCallRe.ReplaceAllStringFunc(text, func(block string) string {
+        m := nativeToolCallRe.FindStringSubmatch(block)
+        if len(m) != 3 {
+            return block
+        }
+        name := strings.TrimSpace(m[1])
+        if name == "" {
+            return block
+        }
+        args := map[string]interface{}{}
+        for _, pair := range nativeArgPairRe.FindAllStringSubmatch(m[2], -1) {
+            key := strings.TrimSpace(pair[1])
+            if key == "" {
+                continue
+            }
+            // Values are raw text, including newlines and quotes; json.Marshal
+            // on the whole map escapes them correctly.
+            args[key] = strings.Trim(pair[2], "\n")
+        }
+        payload := map[string]interface{}{"name": name, "arguments": args}
+        encoded, err := json.Marshal(payload)
+        if err != nil {
+            return block
+        }
+        return agentToolStart + string(encoded) + agentToolEnd
+    })
+}
+
+// drainNativeBlock handles a native tool-call block met while streaming.
+//
+// The block is buffered whole rather than streamed argument-by-argument: its
+// payload is XML, so the incremental JSON scanner the canonical path uses
+// cannot follow it. That matches the interceptor's existing fallback for
+// un-streamable shapes — the client gets one complete tool call instead of
+// live fragments, which is what the alternative (raw XML as assistant text)
+// fails to give at all.
+//
+// handled is false when the caller should continue with the canonical scan.
+// When handled is true, done reports whether the block was consumed (keep
+// scanning) or is still arriving (wait for more chunks).
+func (in *AgentStreamInterceptor) drainNativeBlock(rest string, canonicalStart int, final bool,
+    content *[]string, toolCalls *[]map[string]interface{}) (handled, done bool) {
+    nStart := strings.Index(rest, nativeToolOpen)
+    if nStart < 0 {
+        return false, false
+    }
+    // A canonical marker at or before this point wins: it is the documented
+    // shape and streams properly.
+    if canonicalStart >= 0 && canonicalStart <= nStart {
+        return false, false
+    }
+    endIdx := strings.Index(rest[nStart:], nativeToolClose)
+    if endIdx < 0 {
+        if final {
+            // Truncated block at end of stream: nothing to translate, let the
+            // normal path emit it as content rather than swallowing output.
+            return false, false
+        }
+        // Emit what precedes the block and hold the rest until it closes, so
+        // half a block never reaches the client as text.
+        if nStart > 0 {
+            *content = append(*content, rest[:nStart])
+            in.offset += nStart
+        }
+        return true, false
+    }
+    blockEnd := nStart + endIdx + len(nativeToolClose)
+    if nStart > 0 {
+        *content = append(*content, rest[:nStart])
+    }
+    *toolCalls = append(*toolCalls, ParseAgentToolCalls(rest[nStart:blockEnd])...)
+    in.offset += blockEnd
+    in.pendingSep = true
+    return true, true
+}

--- a/internal/zbridge/agent_native_test.go
+++ b/internal/zbridge/agent_native_test.go
@@ -1,0 +1,140 @@
+package zbridge
+
+import (
+    "encoding/json"
+    "strings"
+    "testing"
+)
+
+// Captured from a real session: glm-5.3 emitted its native syntax mid-run and
+// the whole block reached the client as assistant text.
+const nativeCapture = `<tool_call>bash
+<arg_key>command</arg_key>
+<arg_value>cd ~/Projects/many-proxys && grep -n 'generate-nix' AGENTS.md | wc -l</arg_value>
+<arg_key>i</arg_key>
+<arg_value>Check which pending edits actually applied</arg_value>
+<arg_key>cwd</arg_key>
+<arg_value>/home/finn/Projects/many-proxys</arg_value>
+</tool_call>`
+
+func TestTranslateNativeToolCall(t *testing.T) {
+    calls := ParseAgentToolCalls(nativeCapture)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 tool call, got %d", len(calls))
+    }
+    fn := calls[0]["function"].(map[string]interface{})
+    if fn["name"] != "bash" {
+        t.Fatalf("want name bash, got %v", fn["name"])
+    }
+    var args map[string]interface{}
+    if err := json.Unmarshal([]byte(fn["arguments"].(string)), &args); err != nil {
+        t.Fatalf("arguments are not valid JSON: %v", err)
+    }
+    if !strings.Contains(args["command"].(string), "grep -n 'generate-nix'") {
+        t.Fatalf("command argument lost: %v", args["command"])
+    }
+    if args["cwd"] != "/home/finn/Projects/many-proxys" {
+        t.Fatalf("cwd argument lost: %v", args["cwd"])
+    }
+}
+
+// The block must not also survive as assistant text, or the model imitates its
+// own broken output on the next turn.
+func TestNativeToolCallStripped(t *testing.T) {
+    if got := StripAgentToolCalls("before " + nativeCapture + " after"); strings.Contains(got, "<tool_call>") {
+        t.Fatalf("native block leaked into content: %q", got)
+    }
+}
+
+func TestTranslateNativeMultipleCalls(t *testing.T) {
+    in := nativeCapture + "\n" + `<tool_call>read_file
+<arg_key>path</arg_key>
+<arg_value>config.json</arg_value>
+</tool_call>`
+    calls := ParseAgentToolCalls(in)
+    if len(calls) != 2 {
+        t.Fatalf("want 2 tool calls, got %d", len(calls))
+    }
+}
+
+// Values carry heredocs, quotes and newlines; they must survive JSON encoding.
+func TestTranslateNativeMultilineValue(t *testing.T) {
+    in := `<tool_call>bash
+<arg_key>command</arg_key>
+<arg_value>python3 - <<'EOF'
+s = "it's \"quoted\""
+print(s)
+EOF</arg_value>
+</tool_call>`
+    calls := ParseAgentToolCalls(in)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 tool call, got %d", len(calls))
+    }
+    fn := calls[0]["function"].(map[string]interface{})
+    var args map[string]interface{}
+    if err := json.Unmarshal([]byte(fn["arguments"].(string)), &args); err != nil {
+        t.Fatalf("arguments are not valid JSON: %v", err)
+    }
+    cmd := args["command"].(string)
+    for _, want := range []string{"<<'EOF'", `it's`, `\"quoted\"`, "print(s)", "EOF"} {
+        if !strings.Contains(cmd, want) {
+            t.Fatalf("command lost %q: %q", want, cmd)
+        }
+    }
+}
+
+// Ordinary text and canonical marker blocks must pass through untouched.
+func TestTranslateNativeLeavesOtherTextAlone(t *testing.T) {
+    plain := "Here is some prose mentioning <tool> and </call> but no block."
+    if got := TranslateNativeToolCalls(plain); got != plain {
+        t.Fatalf("plain text rewritten: %q", got)
+    }
+    canonical := agentToolStart + `{"name":"bash","arguments":{"command":"ls"}}` + agentToolEnd
+    if got := TranslateNativeToolCalls(canonical); got != canonical {
+        t.Fatalf("canonical block rewritten: %q", got)
+    }
+}
+
+// ── streaming ────────────────────────────────────────────────────────────────
+
+func TestStreamNativeToolCall(t *testing.T) {
+    // Sizes chosen so the opening marker, the arg tags and the closing marker
+    // each land split across a chunk boundary.
+    for _, size := range []int{1, 3, 7, 13, 64, 4096} {
+        content, calls, args := feedChunks(t, splitRunes("Working on it.\n"+nativeCapture, size), 1)
+        if calls != 1 {
+            t.Fatalf("size %d: want 1 tool call, got %d (content %q)", size, calls, content)
+        }
+        if !strings.Contains(args, "generate-nix") {
+            t.Fatalf("size %d: arguments lost: %q", size, args)
+        }
+        if strings.Contains(content, "<tool_call>") || strings.Contains(content, "arg_key") {
+            t.Fatalf("size %d: native syntax leaked as content: %q", size, content)
+        }
+        if !strings.Contains(content, "Working on it.") {
+            t.Fatalf("size %d: ordinary content lost: %q", size, content)
+        }
+    }
+}
+
+func TestStreamCanonicalStillWins(t *testing.T) {
+    canonical := agentToolStart + `{"name":"ls","arguments":{"path":"/tmp"}}` + agentToolEnd
+    content, calls, _ := feedChunks(t, splitRunes(canonical, 5), 1)
+    if calls != 1 {
+        t.Fatalf("canonical block not parsed while streaming: %d calls, content %q", calls, content)
+    }
+    if strings.Contains(content, "TOOL_CALL") {
+        t.Fatalf("canonical marker leaked as content: %q", content)
+    }
+}
+
+// A block that never closes must still surface as text rather than vanish.
+func TestStreamTruncatedNativeBlockNotSwallowed(t *testing.T) {
+    content, calls, _ := feedChunks(t, splitRunes("prefix <tool_call>bash\n<arg_key>command</arg_key>", 9), 1)
+    if calls != 0 {
+        t.Fatalf("truncated block produced %d calls", calls)
+    }
+    if !strings.Contains(content, "prefix") {
+        t.Fatalf("content before the truncated block lost: %q", content)
+    }
+}


### PR DESCRIPTION
Fixes #27.

## Problem

With `AGENT_MODE=1`, GLM models sometimes answer with the tool-call syntax they were trained on instead of the prompted marker form:

```
<tool_call>bash
<arg_key>command</arg_key>
<arg_value>ls -la</arg_value>
</tool_call>
```

`arg_key` appears nowhere in the codebase, so the block is forwarded verbatim as assistant text and no `tool_calls` are produced — the model looks like it narrated a tool call instead of making one. It compounds: once the unparsed block is in the transcript the model takes its own broken output as the example and keeps emitting that shape, so one slip degrades the rest of the session.

## Change

`TranslateNativeToolCalls` rewrites a native block into the canonical `<<<TOOL_CALL>>>{json}<<<END_TOOL_CALL>>>` form, hooked in at two points so the whole existing pipeline handles it unchanged:

- **`NormalizeAgentFences`** — covers `ParseAgentToolCalls` and `StripAgentToolCalls` in one place.
- **`AgentStreamInterceptor.drain`** — the native block cannot stream argument-by-argument (its payload is XML, not JSON), so it is buffered whole and emitted as one complete call, mirroring the existing `tcFallback` path for un-streamable shapes.

Three properties are covered by tests:

- a canonical marker at or before the same offset keeps priority;
- a half-arrived block is held back rather than leaked as content;
- a block that never closes is still emitted as text rather than swallowed.

## Tests

`agent_native_test.go` — translation, multiple blocks, multi-line values with heredocs and nested quotes, plus streaming at chunk sizes 1, 3, 7, 13, 64 and 4096 bytes (at size 1 every marker straddles a chunk boundary). The capture used as fixture is from a real session.

Existing suite green, `go vet` clean.



---

*Written with AI assistance (Claude), reviewed and tested by me before submitting.*