### PR TITLE
feat(config): accept several accounts in ZAI_TOKEN

### DIFF
--- a/internal/zbridge/config.go
+++ b/internal/zbridge/config.go
@@ -4,6 +4,7 @@ import (
     "os"
     "strconv"
     "strings"
+    "sync/atomic"
     "time"
 )
 
@@ -43,7 +44,14 @@ type Config struct {
         Default int
     }
     ZaiToken  string
-    AgentMode bool
+    // ZaiTokens holds every account token ZAI_TOKEN carried. One account is
+    // one entry; sessions cycle through them so several free accounts share
+    // the load and a per-account quota no longer stops the bridge.
+    // ZaiToken stays the first entry, so single-account setups and anything
+    // reading that field behave exactly as before.
+    ZaiTokens   []string
+    zaiTokenIdx atomic.Uint64
+    AgentMode   bool
     // AgentModeVariant selects the agent-mode compatibility shim:
     //   "modern" (default) — XML-sectioned prompt shim ported from
     //                        DeepseekFreeAPI (see agent.go)
@@ -110,7 +118,10 @@ func loadConfig() *Config {
         }
     }
     if t := os.Getenv("ZAI_TOKEN"); t != "" {
-        c.ZaiToken = t
+        c.ZaiTokens = parseZaiTokens(t)
+        if len(c.ZaiTokens) > 0 {
+            c.ZaiToken = c.ZaiTokens[0]
+        }
     }
     if am := os.Getenv("AGENT_MODE"); am != "" {
         switch strings.ToLower(am) {
@@ -166,6 +177,42 @@ func loadConfig() *Config {
         }
     }
     return c
+}
+
+// parseZaiTokens splits ZAI_TOKEN into individual account tokens. Commas,
+// whitespace and newlines all separate, so a list pasted from a file or an
+// .env one-liner both work; empty fragments are dropped.
+func parseZaiTokens(raw string) []string {
+    fields := strings.FieldsFunc(raw, func(r rune) bool {
+        return r == ',' || r == ';' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+    })
+    tokens := make([]string, 0, len(fields))
+    for _, f := range fields {
+        if f = strings.TrimSpace(f); f != "" {
+            tokens = append(tokens, f)
+        }
+    }
+    return tokens
+}
+
+// NextZaiToken returns the account token for the next session, cycling
+// round-robin when several are configured. It returns "" when none is set,
+// which is what puts the bridge into guest mode.
+//
+// Rotation happens per session, and every stateless request runs on its own
+// throwaway session (see session_pool.go), so consecutive requests land on
+// different accounts. Each session keeps the token it was minted with for
+// its whole lifetime, including the upstream DELETE that retires it.
+func (c *Config) NextZaiToken() string {
+    switch len(c.ZaiTokens) {
+    case 0:
+        return ""
+    case 1:
+        return c.ZaiTokens[0]
+    default:
+        i := c.zaiTokenIdx.Add(1) - 1
+        return c.ZaiTokens[i%uint64(len(c.ZaiTokens))]
+    }
 }
 
 var config = loadConfig()

--- a/internal/zbridge/config_tokens_test.go
+++ b/internal/zbridge/config_tokens_test.go
@@ -1,0 +1,99 @@
+package zbridge
+
+import (
+    "sync"
+    "testing"
+)
+
+func TestParseZaiTokens(t *testing.T) {
+    cases := []struct {
+        name string
+        raw  string
+        want []string
+    }{
+        {"single", "tok1", []string{"tok1"}},
+        {"comma", "tok1,tok2,tok3", []string{"tok1", "tok2", "tok3"}},
+        {"comma and spaces", " tok1 , tok2 ,tok3 ", []string{"tok1", "tok2", "tok3"}},
+        {"newlines", "tok1\ntok2\r\ntok3", []string{"tok1", "tok2", "tok3"}},
+        {"semicolons", "tok1;tok2", []string{"tok1", "tok2"}},
+        {"empty fragments dropped", "tok1,,tok2,", []string{"tok1", "tok2"}},
+        {"blank", "   ", nil},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := parseZaiTokens(tc.raw)
+            if len(got) != len(tc.want) {
+                t.Fatalf("got %v, want %v", got, tc.want)
+            }
+            for i := range got {
+                if got[i] != tc.want[i] {
+                    t.Fatalf("got %v, want %v", got, tc.want)
+                }
+            }
+        })
+    }
+}
+
+func TestNextZaiTokenRotates(t *testing.T) {
+    c := &Config{ZaiTokens: []string{"a", "b", "c"}}
+    var got []string
+    for i := 0; i < 7; i++ {
+        got = append(got, c.NextZaiToken())
+    }
+    want := []string{"a", "b", "c", "a", "b", "c", "a"}
+    for i := range want {
+        if got[i] != want[i] {
+            t.Fatalf("rotation broke at %d: got %v, want %v", i, got, want)
+        }
+    }
+}
+
+func TestNextZaiTokenSingleAndEmpty(t *testing.T) {
+    one := &Config{ZaiTokens: []string{"only"}}
+    for i := 0; i < 3; i++ {
+        if got := one.NextZaiToken(); got != "only" {
+            t.Fatalf("single token changed: %q", got)
+        }
+    }
+    // No token configured is guest mode, which the caller detects as "".
+    none := &Config{}
+    if got := none.NextZaiToken(); got != "" {
+        t.Fatalf("want empty token for guest mode, got %q", got)
+    }
+}
+
+// Sessions are minted concurrently, so the cursor must not hand the same
+// index to two goroutines or skip entries.
+func TestNextZaiTokenConcurrent(t *testing.T) {
+    c := &Config{ZaiTokens: []string{"a", "b", "c", "d"}}
+    const perGoroutine, goroutines = 250, 8
+
+    counts := make([]map[string]int, goroutines)
+    var wg sync.WaitGroup
+    for g := 0; g < goroutines; g++ {
+        wg.Add(1)
+        go func(g int) {
+            defer wg.Done()
+            local := map[string]int{}
+            for i := 0; i < perGoroutine; i++ {
+                local[c.NextZaiToken()]++
+            }
+            counts[g] = local
+        }(g)
+    }
+    wg.Wait()
+
+    total := map[string]int{}
+    for _, local := range counts {
+        for tok, n := range local {
+            total[tok] += n
+        }
+    }
+    want := perGoroutine * goroutines / len(c.ZaiTokens)
+    for _, tok := range c.ZaiTokens {
+        if total[tok] != want {
+            t.Fatalf("token %q used %d times, want %d (uneven rotation: %v)",
+                tok, total[tok], want, total)
+        }
+    }
+}

--- a/internal/zbridge/zai.go
+++ b/internal/zbridge/zai.go
@@ -157,9 +157,14 @@ func initializeSession() error {
         session.mu.Unlock()
     }()
 
-    if config.ZaiToken != "" {
-        log.Println("[Session] Using hardcoded ZAI_TOKEN, skipping guest init.")
-        session.Token = config.ZaiToken
+    if len(config.ZaiTokens) > 0 {
+        if len(config.ZaiTokens) > 1 {
+            log.Printf("[Session] Using ZAI_TOKEN account pool (%d accounts), skipping guest init.",
+                len(config.ZaiTokens))
+        } else {
+            log.Println("[Session] Using hardcoded ZAI_TOKEN, skipping guest init.")
+        }
+        session.Token = config.NextZaiToken()
         id, name := decodeJWT(session.Token)
         session.UserID = id
         if name != "" {


### PR DESCRIPTION
## Problem

`ZAI_TOKEN` holds exactly one account, and the session pool is built around that single identity. When that account hits a quota or `MODEL_CONCURRENCY_LIMIT`, the bridge stops serving even if other free accounts are available.

The workaround is a second instance per account, which also means a second device-token database and a second refill cycle — a lot of moving parts for what is really one extra credential.

## Change

`ZAI_TOKEN` now accepts several tokens, separated by commas, semicolons or whitespace, so both an `.env` one-liner and a pasted list work:

```
ZAI_TOKEN=eyJhbGciOi...,eyJhbGciOi...
```

`NextZaiToken()` hands sessions the next token round-robin. Since every stateless request runs on its own throwaway session (see `session_pool.go`), consecutive requests land on different accounts, and each session keeps the token it was minted with for its whole lifetime — including the upstream `DELETE` that retires it, which therefore always uses the account that owns the chat.

Backwards compatible: `Config.ZaiToken` keeps the first entry, so a single-token configuration behaves exactly as before, and guest mode is still "no token set".

## Tests

`config_tokens_test.go` — separator handling (commas, semicolons, newlines, stray whitespace, empty fragments), rotation order, single-token and guest-mode behaviour, and a concurrency test asserting an even distribution across 8 goroutines, since sessions are minted in parallel. Passes under `-race`; existing suite green and `go vet` clean.

## Note

The cursor is a plain round-robin — it does not skip an account that is rate-limited upstream. Cooldown-aware selection would be the natural follow-up; this change is deliberately limited to making more than one account usable at all.
