### PR TITLE
fix(upstream): pace requests to avoid Aliyun WAF IP blocks

### DIFF
--- a/internal/zbridge/ratelimit.go
+++ b/internal/zbridge/ratelimit.go
@@ -1,0 +1,101 @@
+package zbridge
+
+import (
+    "net/http"
+    "os"
+    "strconv"
+    "sync"
+    "time"
+)
+
+// Upstream pacing.
+//
+// One proxied chat request costs several upstream calls — a captcha challenge,
+// the completion itself, and the DELETE that retires the throwaway chat — and
+// the session pool refills in the background on top of that. Bursts therefore
+// hit chat.z.ai far harder than the request count suggests, and Aliyun's WAF
+// answers a burst by blocking the source IP: every later request comes back as
+// the 405 block page, for hours, no matter which account or session is used.
+//
+// Pacing every upstream call through one shared gate keeps a burst from ever
+// forming. It is deliberately a floor on the gap between requests rather than
+// a token bucket: a bucket lets a burst through as long as the average holds,
+// which is exactly the shape that trips the WAF.
+//
+// UPSTREAM_MIN_INTERVAL_MS tunes it; 0 disables pacing entirely.
+const defaultUpstreamMinIntervalMS = 200
+
+func upstreamMinInterval() time.Duration {
+    raw := os.Getenv("UPSTREAM_MIN_INTERVAL_MS")
+    if raw == "" {
+        return defaultUpstreamMinIntervalMS * time.Millisecond
+    }
+    ms, err := strconv.Atoi(raw)
+    if err != nil || ms < 0 {
+        return defaultUpstreamMinIntervalMS * time.Millisecond
+    }
+    return time.Duration(ms) * time.Millisecond
+}
+
+// pacedTransport spaces out the requests handed to base. Callers block in
+// RoundTrip until their slot is due, so pacing applies no matter which code
+// path issues the call.
+type pacedTransport struct {
+    base http.RoundTripper
+
+    // The interval is resolved on first use, not at package init: these
+    // transports are package-level variables, so reading the environment in
+    // the constructor would freeze the value before main (or TestMain) has
+    // had a chance to set it.
+    gapOnce sync.Once
+    gap     time.Duration
+    gapFor  func() time.Duration
+
+    mu   sync.Mutex
+    next time.Time // earliest instant the next request may start
+}
+
+// newPacedTransport wraps base with the interval from the environment.
+func newPacedTransport(base http.RoundTripper) http.RoundTripper {
+    return &pacedTransport{base: base, gapFor: upstreamMinInterval}
+}
+
+func (t *pacedTransport) minGap() time.Duration {
+    t.gapOnce.Do(func() {
+        gapFor := t.gapFor
+        if gapFor == nil {
+            gapFor = upstreamMinInterval
+        }
+        t.gap = gapFor()
+    })
+    return t.gap
+}
+
+func (t *pacedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    minGap := t.minGap()
+    if minGap <= 0 {
+        return t.base.RoundTrip(req) // pacing disabled
+    }
+
+    // Claim a slot: concurrent callers queue up rather than all waiting for
+    // the same instant and then firing together.
+    t.mu.Lock()
+    now := time.Now()
+    slot := t.next
+    if slot.Before(now) {
+        slot = now
+    }
+    t.next = slot.Add(minGap)
+    t.mu.Unlock()
+
+    if wait := time.Until(slot); wait > 0 {
+        timer := time.NewTimer(wait)
+        defer timer.Stop()
+        select {
+        case <-timer.C:
+        case <-req.Context().Done():
+            return nil, req.Context().Err()
+        }
+    }
+    return t.base.RoundTrip(req)
+}

--- a/internal/zbridge/ratelimit_test.go
+++ b/internal/zbridge/ratelimit_test.go
@@ -1,0 +1,162 @@
+package zbridge
+
+import (
+    "context"
+    "net/http"
+    "net/http/httptest"
+    "sync"
+    "testing"
+    "time"
+)
+
+// recordingTransport notes when each request reached the underlying transport.
+type recordingTransport struct {
+    mu    sync.Mutex
+    times []time.Time
+}
+
+func (r *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    r.mu.Lock()
+    r.times = append(r.times, time.Now())
+    r.mu.Unlock()
+    return &http.Response{
+        StatusCode: 200,
+        Body:       http.NoBody,
+        Request:    req,
+    }, nil
+}
+
+func (r *recordingTransport) gaps() []time.Duration {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    var out []time.Duration
+    for i := 1; i < len(r.times); i++ {
+        out = append(out, r.times[i].Sub(r.times[i-1]))
+    }
+    return out
+}
+
+func TestPacedTransportSpacesSequentialRequests(t *testing.T) {
+    rec := &recordingTransport{}
+    const gap = 40 * time.Millisecond
+    rt := pacedWithGap(rec, gap)
+
+    for i := 0; i < 4; i++ {
+        req := httptest.NewRequest("GET", "https://example.invalid/", nil)
+        if _, err := rt.RoundTrip(req); err != nil {
+            t.Fatalf("request %d: %v", i, err)
+        }
+    }
+    for i, got := range rec.gaps() {
+        // Timers fire no earlier than requested; allow slack for scheduling.
+        if got < gap-5*time.Millisecond {
+            t.Fatalf("gap %d too small: %v, want >= %v", i, got, gap)
+        }
+    }
+}
+
+// A burst is the shape that trips the WAF, so concurrent callers must be
+// spread out too, not merely delayed by the same amount.
+func TestPacedTransportSpreadsBurst(t *testing.T) {
+    rec := &recordingTransport{}
+    const gap = 25 * time.Millisecond
+    const n = 6
+    rt := pacedWithGap(rec, gap)
+
+    var wg sync.WaitGroup
+    start := time.Now()
+    for i := 0; i < n; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            req := httptest.NewRequest("GET", "https://example.invalid/", nil)
+            if _, err := rt.RoundTrip(req); err != nil {
+                t.Errorf("burst request: %v", err)
+            }
+        }()
+    }
+    wg.Wait()
+
+    if got := len(rec.times); got != n {
+        t.Fatalf("want %d requests through, got %d", n, got)
+    }
+    // n requests at one per gap cannot finish faster than (n-1) gaps.
+    if elapsed := time.Since(start); elapsed < time.Duration(n-1)*gap-10*time.Millisecond {
+        t.Fatalf("burst was not paced: %d requests in %v", n, elapsed)
+    }
+}
+
+func TestPacedTransportHonoursContextCancellation(t *testing.T) {
+    rec := &recordingTransport{}
+    rt := pacedWithGap(rec, time.Second)
+
+    // First request claims the slot immediately, the second must wait a second.
+    if _, err := rt.RoundTrip(httptest.NewRequest("GET", "https://example.invalid/", nil)); err != nil {
+        t.Fatalf("first request: %v", err)
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+    defer cancel()
+    req := httptest.NewRequest("GET", "https://example.invalid/", nil).WithContext(ctx)
+    if _, err := rt.RoundTrip(req); err == nil {
+        t.Fatal("want the wait to abort with the request context, got nil error")
+    }
+    if got := len(rec.times); got != 1 {
+        t.Fatalf("cancelled request still reached upstream: %d calls", got)
+    }
+}
+
+// A zero interval must hand the request straight to the base transport.
+func TestPacedTransportDisabled(t *testing.T) {
+    rec := &recordingTransport{}
+    rt := pacedWithGap(rec, 0)
+    start := time.Now()
+    for i := 0; i < 3; i++ {
+        if _, err := rt.RoundTrip(httptest.NewRequest("GET", "https://example.invalid/", nil)); err != nil {
+            t.Fatalf("request %d: %v", i, err)
+        }
+    }
+    if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+        t.Fatalf("pacing still applied with a zero interval: %v", elapsed)
+    }
+}
+
+// The interval is read on first use, so a value set after construction still
+// takes effect — that is what lets TestMain switch pacing off for the mock.
+func TestPacedTransportReadsIntervalLazily(t *testing.T) {
+    rec := &recordingTransport{}
+    rt := newPacedTransport(rec)
+    t.Setenv("UPSTREAM_MIN_INTERVAL_MS", "0")
+    start := time.Now()
+    for i := 0; i < 3; i++ {
+        if _, err := rt.RoundTrip(httptest.NewRequest("GET", "https://example.invalid/", nil)); err != nil {
+            t.Fatalf("request %d: %v", i, err)
+        }
+    }
+    if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+        t.Fatalf("environment set after construction was ignored: %v", elapsed)
+    }
+}
+
+func TestUpstreamMinIntervalFromEnv(t *testing.T) {
+    cases := map[string]time.Duration{
+        "":       defaultUpstreamMinIntervalMS * time.Millisecond,
+        "0":      0,
+        "750":    750 * time.Millisecond,
+        "-5":     defaultUpstreamMinIntervalMS * time.Millisecond,
+        "nonsen": defaultUpstreamMinIntervalMS * time.Millisecond,
+    }
+    for raw, want := range cases {
+        // An empty value reads back as "" from os.Getenv, same as unset.
+        t.Setenv("UPSTREAM_MIN_INTERVAL_MS", raw)
+        if got := upstreamMinInterval(); got != want {
+            t.Fatalf("UPSTREAM_MIN_INTERVAL_MS=%q: got %v, want %v", raw, got, want)
+        }
+    }
+}
+
+// pacedWithGap builds a transport with a fixed interval, bypassing the
+// environment lookup.
+func pacedWithGap(base http.RoundTripper, gap time.Duration) http.RoundTripper {
+    return &pacedTransport{base: base, gapFor: func() time.Duration { return gap }}
+}

--- a/internal/zbridge/util.go
+++ b/internal/zbridge/util.go
@@ -86,7 +86,7 @@ var zlibWriterPool = sync.Pool{
 
 // Optimised client for Aliyun captcha API calls
 var aliyunHTTPClient = &http.Client{
-    Transport: &http.Transport{
+    Transport: newPacedTransport(&http.Transport{
         MaxIdleConns:          100,
         MaxIdleConnsPerHost:   20,
         MaxConnsPerHost:       20,
@@ -95,7 +95,7 @@ var aliyunHTTPClient = &http.Client{
         ExpectContinueTimeout: 1 * time.Second,
         ResponseHeaderTimeout: 15 * time.Second,
         ForceAttemptHTTP2:     true,
-    },
+    }),
     Timeout: 30 * time.Second,
 }
 
@@ -237,7 +237,7 @@ func (c *concatConn) Read(b []byte) (int, error) {
 var zaiJar = &cookieJar{}
 
 var zaiHTTPClient = &http.Client{
-    Transport: &http.Transport{
+    Transport: newPacedTransport(&http.Transport{
         DialTLSContext:        dialUTLS,
         MaxIdleConns:          100,
         MaxIdleConnsPerHost:   20,
@@ -246,7 +246,7 @@ var zaiHTTPClient = &http.Client{
         TLSHandshakeTimeout:   15 * time.Second,
         ExpectContinueTimeout: 1 * time.Second,
         ForceAttemptHTTP2:     false,
-    },
+    }),
     Jar: zaiJar,
 }
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+    "os"
+    "testing"
+)
+
+// Upstream pacing (UPSTREAM_MIN_INTERVAL_MS, see internal/zbridge/ratelimit.go)
+// exists to keep bursts away from chat.z.ai. These tests talk to a local mock,
+// which needs no protection and would otherwise pay the delay on every call —
+// it stretched this suite from ~4 s to ~17 s.
+func TestMain(m *testing.M) {
+    if _, set := os.LookupEnv("UPSTREAM_MIN_INTERVAL_MS"); !set {
+        os.Setenv("UPSTREAM_MIN_INTERVAL_MS", "0")
+    }
+    os.Exit(m.Run())
+}


### PR DESCRIPTION
## Problem

A burst of requests gets the egress IP blocked by Aliyun's WAF. Every later call then comes back as the 405 block page — the same one as in #20 — for hours, and no account, token or fresh session gets around it, because the block sits in front of authentication.

It is easier to trigger than the request count suggests: one proxied chat request costs a captcha challenge, the completion itself and the `DELETE` that retires the throwaway chat, with pool refills on top. A handful of client requests in quick succession is already a sizeable burst upstream.

## Change

All upstream calls go through one shared gate. Both HTTP clients (`zaiHTTPClient` and `aliyunHTTPClient`) get their transport wrapped, so no call path can bypass it — no call site changes.

It enforces a **floor on the gap between requests** rather than a token bucket: a bucket lets a burst through as long as the average holds, which is exactly the shape that trips the WAF. Concurrent callers each claim their own slot, so they queue instead of all waiting for the same instant and then firing together. A waiting request aborts if its context is cancelled.

`UPSTREAM_MIN_INTERVAL_MS` tunes the interval; `0` disables pacing and hands requests straight through. Default is 200 ms.

The interval is resolved on first use, not in the constructor — these transports are package-level variables, so reading the environment at init would freeze the value before `main` (or `TestMain`) can set it.

## Tests

`ratelimit_test.go` — sequential spacing, burst spreading (asserts n requests cannot complete faster than n-1 intervals), context cancellation during the wait, the disabled path, lazy resolution of the environment value, and parsing of the variable itself. Passes under `-race`.

`tests/main_test.go` sets `UPSTREAM_MIN_INTERVAL_MS=0` for the integration suite, which talks to a local mock that needs no protection — without it the suite went from ~4 s to ~17 s.

Existing suite green, `go vet` clean.

## Caveat

I have not been able to verify this against the live WAF: the IP I would test from is currently blocked, which is what prompted the change. The pacing behaviour itself is covered by the tests; the claim that it *prevents* blocks is reasoning about the cause, not a measurement.

---

*Written with AI assistance (Claude), reviewed and tested by me before submitting.*
