### PR TITLE
fix(upstream): fix 405 WAF block by passing signed query params, origin headers, and updating fe-version

### DIFF
--- a/internal/zbridge/config.go
+++ b/internal/zbridge/config.go
@@ -20,8 +20,8 @@ const (
 
     // Z.AI direct config
     SALT_KEY           = "key-@@@@)))()((9))-xxxx&&&%%%%%"
-    DEFAULT_FE_VERSION = "prod-fe-1.1.88"
-    zaiUserAgent       = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    DEFAULT_FE_VERSION = "prod-fe-1.1.93"
+    zaiUserAgent       = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
 )
 
 // BASE_URL is a var (not const) only so tests can point the bridge at a

--- a/internal/zbridge/util.go
+++ b/internal/zbridge/util.go
@@ -207,8 +207,11 @@ func dialUTLS(ctx context.Context, network, addr string) (net.Conn, error) {
         InsecureSkipVerify: false,
     }
 
-    // Chrome 120 fingerprint
-    uConn := utls.UClient(rawConn, config, utls.HelloChrome_120)
+    // HelloChrome_Auto tracks the newest Chrome profile the uTLS version
+    // implements. Pinning an explicit release (this was HelloChrome_120, from
+    // late 2023) turns into a fingerprint no real visitor sends any more, and
+    // Aliyun's WAF answers those with the 405 block page.
+    uConn := utls.UClient(rawConn, config, utls.HelloChrome_Auto)
 
     if err := uConn.HandshakeContext(ctx); err != nil {
         rawConn.Close()

--- a/internal/zbridge/zai.go
+++ b/internal/zbridge/zai.go
@@ -393,8 +393,8 @@ func sendToZAIStream(prompt string, opts struct {
         feVersion := session.FeVersion
         session.mu.Unlock()
 
-        signature, _, _ := generateZaSignature(prompt, token, userID)
-        urlStr := BASE_URL + "/api/v2/chat/completions"
+		signature, _, urlParams := generateZaSignature(prompt, token, userID)
+		urlStr := BASE_URL + "/api/v2/chat/completions?" + urlParams
 
         var messagesField interface{}
         if len(opts.ClientMessagesRaw) > 0 {
@@ -464,13 +464,14 @@ func sendToZAIStream(prompt string, opts struct {
             cancel()
             return fmt.Errorf("Z.AI connection error: %s", err.Error())
         }
-        req.Header.Set("authorization", "Bearer "+token)
-        req.Header.Set("User-Agent", zaiUserAgent)
-        req.Header.Set("content-type", "application/json")
-        req.Header.Set("x-fe-Version", feVersion)
-        req.Header.Set("x-region", "overseas")
-        req.Header.Set("x-signature", signature)
-
+		req.Header.Set("authorization", "Bearer "+token)
+		req.Header.Set("User-Agent", zaiUserAgent)
+		req.Header.Set("content-type", "application/json")
+		req.Header.Set("Origin", BASE_URL)
+		req.Header.Set("Referer", BASE_URL+"/")
+		req.Header.Set("x-fe-Version", feVersion)
+		req.Header.Set("x-region", "overseas")
+		req.Header.Set("x-signature", signature)
         resp, err := zaiHTTPClient.Do(req)
         if err != nil {
             cancel()


### PR DESCRIPTION
### Summary
This PR fixes the `Z.AI error 405` issue returned by Aliyun WAF when sending completion requests to `https://chat.z.ai/api/v2/chat/completions`.

Note: This fix was created and debugged with the assistance of AI.

### Root Cause
Recent updates to the Z.AI web client (`prod-fe-1.1.93`) enforce strict validation on the completion endpoint:
1. Requests without signature query parameters (`?timestamp=...&requestId=...&user_id=...&signature_timestamp=...`) are immediately rejected by Aliyun WAF with HTTP 405. `generateZaSignature()` calculated `urlParams`, but they were not appended to `urlStr`.
2. Missing `Origin: https://chat.z.ai` and `Referer: https://chat.z.ai/` headers triggered bot protection rules.
3. The hardcoded TLS fingerprint was pinned to `utls.HelloChrome_120`, and `DEFAULT_FE_VERSION` was outdated.

### Changes
- `internal/zbridge/zai.go`:
  - Append `urlParams` to the `/api/v2/chat/completions` request URL.
  - Add `Origin` and `Referer` headers to the upstream request.
- `internal/zbridge/util.go`:
  - Use `utls.HelloChrome_Auto` to track modern Chrome profiles and prevent TLS JA3 fingerprint blocks.
- `internal/zbridge/config.go`:
  - Update `DEFAULT_FE_VERSION` to `prod-fe-1.1.93` and update the User-Agent string to match Chrome 133.

### Verification
Tested live against `chat.z.ai` with both non-streaming and streaming completions using `glm-5.3` (HTTP 200 OK received).