### PR TITLE
fix(agent): accept every native tool-call dialect, terminated or not

### DIFF
--- a/internal/zbridge/agent_native.go
+++ b/internal/zbridge/agent_native.go
@@ -3,6 +3,7 @@ package zbridge
 import (
     "encoding/json"
     "regexp"
+    "strconv"
     "strings"
 )
 
@@ -22,21 +23,40 @@ import (
 //
 // Translating the block into the canonical marker form lets the existing
 // parser, streaming interceptor and strip pass handle it unchanged.
-
-var nativeToolCallRe = regexp.MustCompile(`(?s)<tool_call>\s*([A-Za-z0-9_.\-]+)\s*(.*?)</tool_call>`)
+//
+// The same models reach for a second shape, the call written as a function
+// invocation with keyword arguments, usually on one line and usually without
+// the closing tag:
+//
+//	<tool_call>web_search(i="Surveying free proxies", query="proxy github", limit=8)
+//
+// Both halves of that need handling. Without the <arg_key>/<arg_value> tags
+// the argument scan finds nothing and the call arrives with an empty argument
+// object; without the closing tag the block regex does not match at all and
+// the whole line reaches the client as text.
 
 var nativeArgPairRe = regexp.MustCompile(`(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>`)
 
+var nativeNameRe = regexp.MustCompile(`^\s*([A-Za-z0-9_.\-]+)`)
+
+const nativeToolOpen = "<tool_call>"
+const nativeToolClose = "</tool_call>"
+
 // HasNativeToolCall reports whether s contains a complete native block.
 func HasNativeToolCall(s string) bool {
-    return nativeToolCallRe.MatchString(s)
+    for _, sp := range findNativeSpans(s) {
+        if sp.terminated {
+            return true
+        }
+    }
+    return false
 }
 
 // nativeToolCallPrefix reports whether s ends inside what could still grow
 // into a native tool-call block, so a streaming caller knows to hold the tail
 // back instead of leaking half a block to the client.
 func nativeToolCallPrefix(s string) bool {
-    idx := strings.LastIndex(s, "<tool_call>")
+    idx := strings.LastIndex(s, nativeToolOpen)
     if idx < 0 {
         // A bare "<tool_c…" tail may still complete on the next chunk.
         for k := 1; k < len(nativeToolOpen) && k <= len(s); k++ {
@@ -46,30 +66,104 @@ func nativeToolCallPrefix(s string) bool {
         }
         return false
     }
-    return !strings.Contains(s[idx:], "</tool_call>")
+    return !strings.Contains(s[idx:], nativeToolClose)
 }
 
-const nativeToolOpen = "<tool_call>"
-const nativeToolClose = "</tool_call>"
+// ── block scanning ───────────────────────────────────────────────────────────
 
-// TranslateNativeToolCalls rewrites every complete native block into the
-// canonical marker form. Text outside such blocks is returned untouched, and
-// input without a native block is returned unchanged.
-func TranslateNativeToolCalls(text string) string {
-    if !strings.Contains(text, nativeToolOpen) {
-        return text
+// nativeSpan is one <tool_call> block found in a text. end points just past
+// the closing tag, or at the end of the text when the block never closed,
+// which only the last span can be.
+type nativeSpan struct {
+    start, end int
+    body       string
+    terminated bool
+}
+
+// findNativeSpans locates every <tool_call> block, closed or not.
+func findNativeSpans(text string) []nativeSpan {
+    var spans []nativeSpan
+    for pos := 0; ; {
+        idx := strings.Index(text[pos:], nativeToolOpen)
+        if idx < 0 {
+            return spans
+        }
+        start := pos + idx
+        bodyStart := start + len(nativeToolOpen)
+        close := strings.Index(text[bodyStart:], nativeToolClose)
+        if close < 0 {
+            return append(spans, nativeSpan{start: start, end: len(text), body: text[bodyStart:]})
+        }
+        spans = append(spans, nativeSpan{
+            start:      start,
+            end:        bodyStart + close + len(nativeToolClose),
+            body:       text[bodyStart : bodyStart+close],
+            terminated: true,
+        })
+        pos = bodyStart + close + len(nativeToolClose)
     }
-    return nativeToolCallRe.ReplaceAllStringFunc(text, func(block string) string {
-        m := nativeToolCallRe.FindStringSubmatch(block)
-        if len(m) != 3 {
-            return block
+}
+
+// parseNativeBlock reads a block body in whichever dialect the model reached
+// for. Four shapes appear in practice, and the payload's first character
+// picks between them:
+//
+//	bash<arg_key>command</arg_key><arg_value>ls</arg_value>   tagged pairs
+//	bash(command="ls", i="listing")                           keyword arguments
+//	bash{"command":"ls"}                                      name then JSON
+//	{"name":"bash","arguments":{"command":"ls"}}              JSON envelope
+//
+// ok is false when no name can be read; args is empty when the payload uses
+// no recognised argument form, which keeps a call with an unreadable tail
+// from being dropped entirely.
+func parseNativeBlock(body string) (name string, args map[string]interface{}, ok bool) {
+    trimmed := strings.TrimSpace(body)
+    if n, a, damaged := parseDamagedCanonical(trimmed); damaged {
+        return n, a, true
+    }
+    if strings.HasPrefix(trimmed, "{") {
+        return parseNativeJSONEnvelope(trimmed)
+    }
+    m := nativeNameRe.FindStringSubmatch(trimmed)
+    if m == nil {
+        return "", nil, false
+    }
+    return m[1], nativeArgsFrom(trimmed[len(m[0]):]), true
+}
+
+// parseNativeJSONEnvelope reads the {"name":…, "arguments":…} shape. The
+// arguments key is spelled three different ways by different fine-tunes, and
+// some emit them as a JSON string rather than an object.
+func parseNativeJSONEnvelope(payload string) (string, map[string]interface{}, bool) {
+    var env map[string]interface{}
+    if json.Unmarshal([]byte(payload), &env) != nil {
+        return "", nil, false
+    }
+    name, _ := env["name"].(string)
+    if name == "" {
+        return "", nil, false
+    }
+    for _, key := range []string{"arguments", "parameters", "args"} {
+        switch v := env[key].(type) {
+        case map[string]interface{}:
+            return name, v, true
+        case string:
+            var nested map[string]interface{}
+            if json.Unmarshal([]byte(v), &nested) == nil {
+                return name, nested, true
+            }
         }
-        name := strings.TrimSpace(m[1])
-        if name == "" {
-            return block
-        }
-        args := map[string]interface{}{}
-        for _, pair := range nativeArgPairRe.FindAllStringSubmatch(m[2], -1) {
+    }
+    return name, map[string]interface{}{}, true
+}
+
+// nativeArgsFrom reads a payload in whichever argument shape it uses. An
+// unrecognised payload yields an empty argument set, which is what this path
+// did before the other dialects were handled.
+func nativeArgsFrom(payload string) map[string]interface{} {
+    args := map[string]interface{}{}
+    if pairs := nativeArgPairRe.FindAllStringSubmatch(payload, -1); len(pairs) > 0 {
+        for _, pair := range pairs {
             key := strings.TrimSpace(pair[1])
             if key == "" {
                 continue
@@ -78,14 +172,326 @@ func TranslateNativeToolCalls(text string) string {
             // on the whole map escapes them correctly.
             args[key] = strings.Trim(pair[2], "\n")
         }
-        payload := map[string]interface{}{"name": name, "arguments": args}
-        encoded, err := json.Marshal(payload)
-        if err != nil {
-            return block
+        return args
+    }
+    trimmed := strings.TrimSpace(payload)
+    if strings.HasPrefix(trimmed, "{") {
+        var obj map[string]interface{}
+        if json.Unmarshal([]byte(trimmed), &obj) == nil {
+            return obj
         }
-        return agentToolStart + string(encoded) + agentToolEnd
-    })
+    }
+    if kwargs, ok := parseNativeKwargs(trimmed); ok {
+        return kwargs
+    }
+    return args
 }
+
+// ── translation ──────────────────────────────────────────────────────────────
+
+// TranslateNativeToolCalls rewrites every native block into the canonical
+// marker form, including a block left unterminated at the end of the text.
+// Text outside such blocks is returned untouched, and input without a native
+// block is returned unchanged.
+func TranslateNativeToolCalls(text string) string {
+    if !strings.Contains(text, nativeToolOpen) {
+        return text
+    }
+    var b strings.Builder
+    prev := 0
+    for _, sp := range findNativeSpans(text) {
+        name, args, ok := parseNativeBlock(sp.body)
+        // An unterminated block is only translated when its payload is
+        // finished; see nativeBodyComplete.
+        if !ok || (!sp.terminated && !nativeBodyComplete(sp.body)) {
+            continue
+        }
+        encoded, err := json.Marshal(map[string]interface{}{"name": name, "arguments": args})
+        if err != nil {
+            continue
+        }
+        b.WriteString(text[prev:sp.start])
+        b.WriteString(agentToolStart + string(encoded) + agentToolEnd)
+        prev = sp.end
+    }
+    if prev == 0 {
+        return text
+    }
+    b.WriteString(text[prev:])
+    return b.String()
+}
+
+// ── unterminated blocks ──────────────────────────────────────────────────────
+
+// nativeBodyComplete reports whether an unterminated body stops on a boundary
+// where nothing is half-written: every argument it began is finished, so the
+// closing tag is the only thing missing.
+//
+// This is the safety condition for recovery, and the reason each dialect is
+// checked rather than assumed. A body that stops mid-argument must stay text:
+// turning a truncated `rm -rf /home/user/proj` into a tool call hands the
+// client a command the model never finished writing.
+func nativeBodyComplete(body string) bool {
+    trimmed := strings.TrimSpace(body)
+    if trimmed == "" {
+        return false
+    }
+    if _, _, ok := parseDamagedCanonical(trimmed); ok {
+        // The canonical closing marker ends it; nothing is still arriving.
+        return true
+    }
+    if strings.HasPrefix(trimmed, "{") {
+        return json.Valid([]byte(trimmed))
+    }
+    m := nativeNameRe.FindStringSubmatch(trimmed)
+    if m == nil {
+        return false
+    }
+    rest := strings.TrimSpace(trimmed[len(m[0]):])
+    switch {
+    case rest == "":
+        // Just the name so far; the arguments may still be arriving.
+        return false
+    case strings.HasPrefix(rest, "("):
+        _, ok := parseNativeKwargs(rest)
+        return ok
+    case strings.HasPrefix(rest, "{"):
+        return json.Valid([]byte(rest))
+    case nativeArgPairRe.MatchString(rest):
+        return strings.TrimSpace(nativeArgPairRe.ReplaceAllString(rest, "")) == ""
+    }
+    return false
+}
+
+// nativeTailRecoverable reports whether text ends in an unterminated block
+// that may be translated despite the missing closing tag.
+func nativeTailRecoverable(text string) bool {
+    spans := findNativeSpans(text)
+    if len(spans) == 0 {
+        return false
+    }
+    last := spans[len(spans)-1]
+    if last.terminated {
+        return false
+    }
+    _, _, ok := parseNativeBlock(last.body)
+    return ok && nativeBodyComplete(last.body)
+}
+
+// ── damaged canonical blocks ─────────────────────────────────────────────────
+
+// parseDamagedCanonical salvages a block that mixes both syntaxes:
+//
+//	<tool_call>bash
+//	 arguments":{"i":"…","command":"grep …"} <<<END_TOOL_CALL>>>
+//
+// The canonical closing marker is present but its opening marker is not, and
+// the JSON has lost its `{"name":"bash",` head. That is not a shape any model
+// writes. It is what an upstream rewrite leaves behind when it replaces one
+// attempt with another and the already-forwarded prefix cannot be taken back
+// (issue #23). The name survives in the native opener and the arguments object
+// survives whole, so the call is recoverable.
+//
+// The closing marker is required as the anchor, and the arguments object must
+// parse as JSON. That parse is the integrity check: a splice landing inside
+// the object would almost certainly unbalance its braces or quotes, so a
+// payload that still parses is very unlikely to be the corrupted one.
+func parseDamagedCanonical(body string) (string, map[string]interface{}, bool) {
+    if !strings.Contains(body, agentToolEnd) {
+        return "", nil, false
+    }
+    m := nativeNameRe.FindStringSubmatch(body)
+    if m == nil {
+        return "", nil, false
+    }
+    name := m[1]
+    rest := body[len(m[0]):]
+    key := strings.Index(rest, "arguments\"")
+    if key < 0 {
+        return "", nil, false
+    }
+    brace := strings.Index(rest[key:], "{")
+    if brace < 0 {
+        return "", nil, false
+    }
+    obj, ok := balancedJSONObject(rest[key+brace:])
+    if !ok {
+        return "", nil, false
+    }
+    var args map[string]interface{}
+    if json.Unmarshal([]byte(obj), &args) != nil {
+        return "", nil, false
+    }
+    return name, args, true
+}
+
+// balancedJSONObject returns the object starting at s[0] == '{', honouring
+// strings and escapes so a brace inside a value does not close it.
+func balancedJSONObject(s string) (string, bool) {
+    if len(s) == 0 || s[0] != '{' {
+        return "", false
+    }
+    depth := 0
+    inString := false
+    for i := 0; i < len(s); i++ {
+        c := s[i]
+        if inString {
+            switch c {
+            case '\\':
+                i++
+            case '"':
+                inString = false
+            }
+            continue
+        }
+        switch c {
+        case '"':
+            inString = true
+        case '{':
+            depth++
+        case '}':
+            depth--
+            if depth == 0 {
+                return s[:i+1], true
+            }
+        }
+    }
+    return "", false
+}
+
+// ── parenthesised argument lists ─────────────────────────────────────────────
+
+// parseNativeKwargs reads `(key="value", n=8, flag=true)`. Values are quoted
+// strings in either quote style with backslash escapes honoured, numbers,
+// booleans or null; anything else is kept as a bare string.
+//
+// ok is false when the list is not closed or an entry is malformed. The caller
+// then leaves the block as text instead of inventing arguments for it, which
+// is also what keeps a still-arriving call from being recovered early, since
+// its argument list has no closing parenthesis yet.
+func parseNativeKwargs(s string) (map[string]interface{}, bool) {
+    s = strings.TrimSpace(s)
+    if len(s) < 2 || !strings.HasPrefix(s, "(") || !strings.HasSuffix(s, ")") {
+        return nil, false
+    }
+    body := s[1 : len(s)-1]
+    args := map[string]interface{}{}
+    for i := 0; ; {
+        for i < len(body) && (isNativeSpace(body[i]) || body[i] == ',') {
+            i++
+        }
+        if i >= len(body) {
+            break
+        }
+        keyStart := i
+        for i < len(body) && isNativeIdent(body[i]) {
+            i++
+        }
+        if i == keyStart {
+            return nil, false
+        }
+        key := body[keyStart:i]
+        for i < len(body) && isNativeSpace(body[i]) {
+            i++
+        }
+        if i >= len(body) || body[i] != '=' {
+            return nil, false
+        }
+        i++
+        for i < len(body) && isNativeSpace(body[i]) {
+            i++
+        }
+        value, next, ok := readNativeValue(body, i)
+        if !ok {
+            return nil, false
+        }
+        args[key] = value
+        i = next
+    }
+    if len(args) == 0 {
+        return nil, false
+    }
+    return args, true
+}
+
+// readNativeValue reads one value starting at i and returns the offset just
+// past it.
+func readNativeValue(s string, i int) (interface{}, int, bool) {
+    if i >= len(s) {
+        return nil, i, false
+    }
+    if quote := s[i]; quote == '"' || quote == '\'' {
+        var b strings.Builder
+        for i++; i < len(s); {
+            switch s[i] {
+            case '\\':
+                if i+1 >= len(s) {
+                    return nil, i, false
+                }
+                b.WriteString(unescapeNative(s[i+1]))
+                i += 2
+            case quote:
+                return b.String(), i + 1, true
+            default:
+                b.WriteByte(s[i])
+                i++
+            }
+        }
+        // Closing quote missing: the value is still being written.
+        return nil, i, false
+    }
+    start := i
+    for i < len(s) && s[i] != ',' {
+        i++
+    }
+    raw := strings.TrimSpace(s[start:i])
+    if raw == "" {
+        return nil, i, false
+    }
+    return nativeScalar(raw), i, true
+}
+
+func unescapeNative(c byte) string {
+    switch c {
+    case 'n':
+        return "\n"
+    case 't':
+        return "\t"
+    case 'r':
+        return "\r"
+    default:
+        return string(c)
+    }
+}
+
+// nativeScalar types an unquoted value the way JSON would.
+func nativeScalar(raw string) interface{} {
+    switch raw {
+    case "true", "True":
+        return true
+    case "false", "False":
+        return false
+    case "null", "None", "nil":
+        return nil
+    }
+    if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+        return n
+    }
+    if f, err := strconv.ParseFloat(raw, 64); err == nil {
+        return f
+    }
+    return raw
+}
+
+func isNativeSpace(c byte) bool {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isNativeIdent(c byte) bool {
+    return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_' || c == '.' || c == '-'
+}
+
+// ── streaming ────────────────────────────────────────────────────────────────
 
 // drainNativeBlock handles a native tool-call block met while streaming.
 //
@@ -113,9 +519,22 @@ func (in *AgentStreamInterceptor) drainNativeBlock(rest string, canonicalStart i
     endIdx := strings.Index(rest[nStart:], nativeToolClose)
     if endIdx < 0 {
         if final {
-            // Truncated block at end of stream: nothing to translate, let the
-            // normal path emit it as content rather than swallowing output.
-            return false, false
+            // End of stream with the block still open. The model routinely
+            // drops the closing tag on the parenthesised form, so when the
+            // payload itself is finished the tag is the only thing missing and
+            // the call is recovered. A payload that stops mid-argument is left
+            // to the normal path, which emits it as content rather than
+            // swallowing output or fabricating a half-written call.
+            if !nativeTailRecoverable(rest[nStart:]) {
+                return false, false
+            }
+            if nStart > 0 {
+                *content = append(*content, rest[:nStart])
+            }
+            *toolCalls = append(*toolCalls, ParseAgentToolCalls(rest[nStart:])...)
+            in.offset += len(rest)
+            in.pendingSep = true
+            return true, true
         }
         // Emit what precedes the block and hold the rest until it closes, so
         // half a block never reaches the client as text.

--- a/internal/zbridge/agent_native_test.go
+++ b/internal/zbridge/agent_native_test.go
@@ -138,3 +138,249 @@ func TestStreamTruncatedNativeBlockNotSwallowed(t *testing.T) {
         t.Fatalf("content before the truncated block lost: %q", content)
     }
 }
+
+// ── parenthesised argument lists ─────────────────────────────────────────────
+
+// Captured from a real session: glm-5.3 wrote the call as a function
+// invocation and left the closing tag off, so the block regex missed it
+// entirely and the line arrived as assistant text.
+const nativeKwargsCapture = `<tool_call>web_search(i="Surveying current free LLM proxy projects", ` +
+    `query="free LLM web chat OpenAI-compatible API proxy github 2026 free tier scraper", limit=8)`
+
+// A second capture of the same shape, from another session.
+const nativeKwargsCapture2 = `<tool_call>grep(i="Finding locally-built services in compose", ` +
+    `pattern="build:|dockerfile_inline|context:", path="docker-compose.yaml")`
+
+func nativeCallArgs(t *testing.T, text string) (string, map[string]interface{}) {
+    t.Helper()
+    calls := ParseAgentToolCalls(text)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 tool call, got %d (from %q)", len(calls), text)
+    }
+    fn := calls[0]["function"].(map[string]interface{})
+    var args map[string]interface{}
+    if err := json.Unmarshal([]byte(fn["arguments"].(string)), &args); err != nil {
+        t.Fatalf("arguments are not valid JSON: %v", err)
+    }
+    return fn["name"].(string), args
+}
+
+func TestTranslateNativeKwargsClosed(t *testing.T) {
+    name, args := nativeCallArgs(t, nativeKwargsCapture+"</tool_call>")
+    if name != "web_search" {
+        t.Fatalf("want name web_search, got %q", name)
+    }
+    if args["query"] != "free LLM web chat OpenAI-compatible API proxy github 2026 free tier scraper" {
+        t.Fatalf("query argument lost: %v", args["query"])
+    }
+    if args["i"] != "Surveying current free LLM proxy projects" {
+        t.Fatalf("i argument lost: %v", args["i"])
+    }
+    if args["limit"] != float64(8) {
+        t.Fatalf("want limit 8 as a number, got %#v", args["limit"])
+    }
+}
+
+// The closing tag is the half the model omits most often; without recovery the
+// whole line reaches the client as text.
+func TestTranslateNativeKwargsUnterminated(t *testing.T) {
+    for _, capture := range []string{nativeKwargsCapture, nativeKwargsCapture2} {
+        name, args := nativeCallArgs(t, "Let me look that up.\n"+capture)
+        if name != "web_search" && name != "grep" {
+            t.Fatalf("unexpected name %q", name)
+        }
+        if args["i"] == nil || args["i"] == "" {
+            t.Fatalf("%s: intent argument lost: %#v", name, args)
+        }
+    }
+}
+
+func TestNativeKwargsStrippedFromContent(t *testing.T) {
+    got := StripAgentToolCalls("Let me look that up.\n" + nativeKwargsCapture)
+    if strings.Contains(got, "<tool_call>") || strings.Contains(got, "web_search(") {
+        t.Fatalf("unterminated block leaked into content: %q", got)
+    }
+    if !strings.Contains(got, "Let me look that up.") {
+        t.Fatalf("ordinary content lost: %q", got)
+    }
+}
+
+func TestNativeKwargsScalars(t *testing.T) {
+    _, args := nativeCallArgs(t,
+        `<tool_call>t(n=8, f=1.5, yes=true, no=false, nothing=null, bare=abc, esc="a\nb")</tool_call>`)
+    if args["n"] != float64(8) || args["f"] != 1.5 {
+        t.Fatalf("numbers mistyped: %#v", args)
+    }
+    if args["yes"] != true || args["no"] != false {
+        t.Fatalf("booleans mistyped: %#v", args)
+    }
+    if v, ok := args["nothing"]; !ok || v != nil {
+        t.Fatalf("null mistyped: %#v", args)
+    }
+    if args["bare"] != "abc" {
+        t.Fatalf("bare word mistyped: %#v", args["bare"])
+    }
+    if args["esc"] != "a\nb" {
+        t.Fatalf("escape not decoded: %q", args["esc"])
+    }
+}
+
+func TestStreamNativeKwargsUnterminated(t *testing.T) {
+    for _, size := range []int{1, 3, 7, 13, 64, 4096} {
+        content, calls, args := feedChunks(t, splitRunes("Working on it.\n"+nativeKwargsCapture, size), 1)
+        if calls != 1 {
+            t.Fatalf("size %d: want 1 tool call, got %d (content %q)", size, calls, content)
+        }
+        if !strings.Contains(args, "OpenAI-compatible") {
+            t.Fatalf("size %d: arguments lost: %q", size, args)
+        }
+        if strings.Contains(content, "<tool_call>") || strings.Contains(content, "web_search(") {
+            t.Fatalf("size %d: native syntax leaked as content: %q", size, content)
+        }
+        if !strings.Contains(content, "Working on it.") {
+            t.Fatalf("size %d: ordinary content lost: %q", size, content)
+        }
+    }
+}
+
+// ── every dialect the models reach for ───────────────────────────────────────
+
+// The shim asks for one format; the models emit whichever they were trained
+// on. Each of these must land as a tool call rather than as assistant text,
+// closed or not.
+func TestNativeDialects(t *testing.T) {
+    for _, tc := range []struct {
+        label string
+        block string
+    }{
+        {"tagged pairs", "<tool_call>bash\n<arg_key>command</arg_key>\n<arg_value>ls -la</arg_value>\n</tool_call>"},
+        {"keyword args", `<tool_call>bash(command="ls -la")</tool_call>`},
+        {"name then JSON", `<tool_call>bash{"command":"ls -la"}</tool_call>`},
+        {"JSON envelope", `<tool_call>{"name":"bash","arguments":{"command":"ls -la"}}</tool_call>`},
+        {"JSON envelope, string args", `<tool_call>{"name":"bash","arguments":"{\"command\":\"ls -la\"}"}</tool_call>`},
+        {"JSON envelope, parameters key", `<tool_call>{"name":"bash","parameters":{"command":"ls -la"}}</tool_call>`},
+    } {
+        for _, variant := range []struct {
+            suffix string
+            text   string
+        }{
+            {" closed", tc.block},
+            {" unterminated", strings.TrimSuffix(tc.block, "</tool_call>")},
+        } {
+            name, args := nativeCallArgs(t, "Working on it.\n"+variant.text)
+            if name != "bash" {
+                t.Fatalf("%s%s: want name bash, got %q", tc.label, variant.suffix, name)
+            }
+            if args["command"] != "ls -la" {
+                t.Fatalf("%s%s: command lost: %#v", tc.label, variant.suffix, args)
+            }
+            if got := StripAgentToolCalls("Working on it.\n" + variant.text); strings.Contains(got, "<tool_call>") {
+                t.Fatalf("%s%s: block leaked as content: %q", tc.label, variant.suffix, got)
+            }
+        }
+    }
+}
+
+// Recovery must never fabricate a call from a payload that stopped mid-write,
+// in any dialect.
+func TestNativeTruncatedDialectsNotRecovered(t *testing.T) {
+    for _, truncated := range []string{
+        `<tool_call>bash(command="rm -rf /home/finn/Proj`,
+        `<tool_call>bash(command="ls", cwd=`,
+        `<tool_call>bash{"command":"rm -rf /home/finn/Proj`,
+        `<tool_call>{"name":"bash","arguments":{"command":"rm -rf`,
+        `<tool_call>bash`,
+        "<tool_call>bash\n<arg_key>command</arg_key>",
+    } {
+        if calls := ParseAgentToolCalls(truncated); len(calls) != 0 {
+            t.Fatalf("truncated payload %q produced %d calls", truncated, len(calls))
+        }
+        if got := StripAgentToolCalls("before " + truncated); !strings.Contains(got, "before") {
+            t.Fatalf("content before a truncated block lost: %q", got)
+        }
+    }
+}
+
+// A closed block followed by an unterminated one: the first is translated
+// regardless, the second only on its own merits.
+func TestNativeMixedTerminationInOneText(t *testing.T) {
+    in := `<tool_call>read_file{"path":"a.txt"}</tool_call>` + "\nthen\n" +
+        `<tool_call>grep(pattern="x", path="b.txt")`
+    calls := ParseAgentToolCalls(in)
+    if len(calls) != 2 {
+        t.Fatalf("want 2 tool calls, got %d", len(calls))
+    }
+    if got := StripAgentToolCalls(in); !strings.Contains(got, "then") {
+        t.Fatalf("text between the blocks lost: %q", got)
+    }
+}
+
+func TestStreamNativeDialects(t *testing.T) {
+    for _, block := range []string{
+        `<tool_call>bash{"command":"ls -la"}`,
+        `<tool_call>{"name":"bash","arguments":{"command":"ls -la"}}`,
+        `<tool_call>bash(command="ls -la")`,
+    } {
+        for _, size := range []int{1, 3, 7, 13, 64, 4096} {
+            content, calls, args := feedChunks(t, splitRunes("Working on it.\n"+block, size), 1)
+            if calls != 1 {
+                t.Fatalf("%q at size %d: want 1 call, got %d (content %q)", block, size, calls, content)
+            }
+            if !strings.Contains(args, "ls -la") {
+                t.Fatalf("%q at size %d: arguments lost: %q", block, size, args)
+            }
+            if strings.Contains(content, "<tool_call>") {
+                t.Fatalf("%q at size %d: leaked as content: %q", block, size, content)
+            }
+        }
+    }
+}
+
+// ── damaged canonical blocks ─────────────────────────────────────────────────
+
+// Captured live: the block carries Zhipu's native opener AND the canonical
+// closing marker, and the JSON has lost its {"name":…, head. No model writes
+// this; it is what an upstream rewrite leaves behind (issue #23).
+const damagedCapture = "<tool_call>bash\n arguments\":{\"i\":\"Inspecting merge conflict in openai.go\"," +
+    "\"command\":\"grep -n -A6 -B6 '<<<<<<<' ../aistudio2api/internal/api/openai.go\"} <<<END_TOOL_CALL>>>"
+
+func TestDamagedCanonicalSalvaged(t *testing.T) {
+    name, args := nativeCallArgs(t, "Ich sehe nach.\n"+damagedCapture)
+    if name != "bash" {
+        t.Fatalf("want name bash, got %q", name)
+    }
+    if !strings.Contains(args["command"].(string), "grep -n -A6 -B6") {
+        t.Fatalf("command lost: %#v", args["command"])
+    }
+    if args["i"] != "Inspecting merge conflict in openai.go" {
+        t.Fatalf("intent lost: %#v", args["i"])
+    }
+    got := StripAgentToolCalls("Ich sehe nach.\n" + damagedCapture)
+    for _, leftover := range []string{"<tool_call>", "arguments\":", "END_TOOL_CALL"} {
+        if strings.Contains(got, leftover) {
+            t.Fatalf("%q left in content: %q", leftover, got)
+        }
+    }
+    if !strings.Contains(got, "Ich sehe nach.") {
+        t.Fatalf("ordinary content lost: %q", got)
+    }
+}
+
+// The closing marker is the anchor and the JSON parse is the integrity check.
+// Without either, the block stays text rather than becoming a call built from
+// a payload that may itself be spliced.
+func TestDamagedCanonicalNeedsAnchorAndValidJSON(t *testing.T) {
+    for _, tc := range []struct {
+        label string
+        block string
+    }{
+        {"no closing marker", "<tool_call>bash\n arguments\":{\"command\":\"ls\"}"},
+        {"unbalanced JSON", "<tool_call>bash\n arguments\":{\"command\":\"ls\" <<<END_TOOL_CALL>>>"},
+        {"no arguments key", "<tool_call>bash\n whatever <<<END_TOOL_CALL>>>"},
+        {"no name", "<tool_call>\n arguments\":{\"command\":\"ls\"} <<<END_TOOL_CALL>>>"},
+    } {
+        if calls := ParseAgentToolCalls(tc.block); len(calls) != 0 {
+            t.Fatalf("%s: produced %d calls", tc.label, len(calls))
+        }
+    }
+}


### PR DESCRIPTION
## Problem

#28 translates Zhipu's native `<tool_call>` block, but only in the shape it was captured in: closed by `</tool_call>`, arguments in `<arg_key>`/`<arg_value>` pairs.

The shim prompt asks for one format and the models emit whichever they were trained on. Chasing the shapes one at a time leaves the next one leaking as assistant text, the failure #28 set out to remove, including the part where the model then imitates its own broken output on the next turn. This PR started as a fix for one more dialect and was widened to stop the pattern repeating.

Two captures that prompted it, from separate sessions, both without the closing tag:

```
<tool_call>web_search(i="Surveying current free LLM proxy projects", query="free LLM web chat OpenAI-compatible API proxy github 2026 free tier scraper", limit=8)
<tool_call>grep(i="Finding locally-built services in compose", pattern="build:|dockerfile_inline|context:", path="docker-compose.yaml")
```

Two things defeat the current pass here. Without the argument tags the pair scan finds nothing, so the call would arrive with an empty argument object, quieter than a visible leak and worse. Without the closing tag `nativeToolCallRe` does not match at all, so the whole line reaches the client verbatim.

## Change

The block scan is dialect-agnostic. `findNativeSpans` locates every block, closed or not, and the payload's first character picks the reader:

```
bash<arg_key>command</arg_key><arg_value>ls</arg_value>   tagged pairs (#28)
bash(command="ls", i="listing")                           keyword arguments
bash{"command":"ls"}                                      name then JSON
{"name":"bash","arguments":{"command":"ls"}}              JSON envelope
```

The JSON envelope also accepts `parameters` and `args` as the argument key, and arguments delivered as a JSON string rather than an object. Keyword values are typed the way JSON would: quoted strings in either quote style with backslash escapes decoded, ints, floats, booleans, null; an entry that parses as none of those is kept as a bare string rather than dropped.

The tagged-pair path is unchanged and still tried first, so nothing about #28's behaviour moves.

### One shape that is damage, not a dialect

```
<tool_call>bash
 arguments":{"i":"Inspecting merge conflict in openai.go","command":"grep -n -A6 -B6 '<<<<<<<' ../aistudio2api/internal/api/openai.go"} <<<END_TOOL_CALL>>>
```

Zhipu's native opener, the canonical closing marker, and a JSON payload that has lost its `{"name":"bash",` head. No model writes that. It is what an upstream rewrite leaves behind when it replaces one attempt with another and the already forwarded prefix cannot be taken back (issue #23). Measured against this branch before the salvage was added: zero calls, the whole thing leaks.

Both halves that matter survived, the name in the native opener and the arguments object whole, so it is recovered under two conditions. The canonical closing marker must be present as the anchor, and the arguments object must parse as JSON. That parse is deliberately the integrity check rather than a formality: a splice landing inside the object would almost certainly unbalance its braces or quotes, so a payload that still parses is very unlikely to be the corrupted one. Four negative cases are in the tests.

## The safety gate

**Recovery of an unterminated block is gated on the payload being finished, per dialect.** A keyword list must close its parenthesis and every quoted value; a JSON payload must parse; an arg-pair payload must leave nothing dangling after the last `</arg_value>`. Anything that stops mid-argument keeps the old behaviour and surfaces as text.

That gate is the point of the change rather than a detail of it. Turning a truncated `bash(command="rm -rf /home/user/proj` into a tool call hands the client a command the model never finished writing, which is worse than the leak this fixes. The existing `TestStreamTruncatedNativeBlockNotSwallowed` covers the arg-pair half of that condition and still passes unchanged.

## Tests

- every dialect, closed and unterminated, through `ParseAgentToolCalls` and `StripAgentToolCalls`
- the damaged mixture, plus four variants that must stay text (no marker, unbalanced JSON, no `arguments` key, no name)
- a mixed text where a closed block precedes an unterminated one
- scalar typing: ints, floats, booleans, null, bare words, `\n` escapes
- six truncated payloads across the dialects that must produce zero calls while leaving the text before them intact
- the streaming path at six chunk sizes per dialect

Existing suite green, `go vet` clean.

## Verification

The patched build ran against live `chat.z.ai` (glm-5.3): non-streaming tool call, plain completion and streaming tool call all behave as before. The recovery paths are covered by the captures and synthetic blocks rather than by live reproduction, since the dialect appears when the model chooses it, which I cannot trigger on demand.

## Note on style

The repository is indented with four spaces rather than tabs, so this patch matches that instead of running `gofmt`, which would rewrite every file in `internal/zbridge`. Happy to submit a separate formatting pass if you would rather the tree were gofmt-clean.
