### PR TITLE
fix(log): thread request id into SSE debug lines

### DIFF
--- a/internal/zbridge/anthropic.go
+++ b/internal/zbridge/anthropic.go
@@ -419,6 +419,7 @@ func anthropicMessagesHandler(w http.ResponseWriter, r *http.Request) {
         ClientMessagesRaw: transformedMessages,
         ReasoningEffort:   body.ReasoningEffort,
         Files:             files,
+        RequestID:         requestId,
     }
 
     if body.Reasoning != nil {

--- a/internal/zbridge/handlers.go
+++ b/internal/zbridge/handlers.go
@@ -122,6 +122,7 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
         ClientMessagesRaw: transformedMessages,
         ReasoningEffort:   body.ReasoningEffort,
         Files:             files,
+        RequestID:         requestId,
     }
 
     // Parse thinking configuration:

--- a/internal/zbridge/sse_garble_test.go
+++ b/internal/zbridge/sse_garble_test.go
@@ -49,7 +49,7 @@ func runSSEParser(t *testing.T, body string) []ZAIResult {
 	go func() {
 		// sendToZAI closes the channel after sendToZAIStream returns;
 		// mirror that here so the drain loop terminates.
-		errCh <- streamSSEResponse(strings.NewReader(body), ch)
+		errCh <- streamSSEResponse(strings.NewReader(body), ch, "")
 		close(ch)
 	}()
 	var results []ZAIResult

--- a/internal/zbridge/sse_requestid_test.go
+++ b/internal/zbridge/sse_requestid_test.go
@@ -1,0 +1,72 @@
+package zbridge
+
+import (
+    "log"
+    "strings"
+    "testing"
+)
+
+// streamSSEResponse prefixes its debug output with the request id when one is
+// given, so concurrent streams can be attributed in a shared log (issue #36).
+func TestSSEDebugLinesCarryRequestId(t *testing.T) {
+    origW := log.Writer()
+    origFlags := log.Flags()
+    defer log.SetOutput(origW)
+    defer log.SetFlags(origFlags)
+
+    var sb strings.Builder
+    log.SetOutput(&sb)
+    log.SetFlags(0)
+
+    ch := make(chan ZAIResult, 16)
+    body := "data: {\"data\":{\"delta_content\":\"hello\"}}\n\n" +
+        "data: {\"data\":{\"phase\":\"done\"}}\n\n" +
+        "data: [DONE]\n\n"
+    err := streamSSEResponse(strings.NewReader(body), ch, "req-abc123")
+    close(ch)
+    if err != nil {
+        t.Fatalf("streamSSEResponse: %v", err)
+    }
+    for range ch { // drain; the real flow's sender closes ch after the call
+    }
+
+    out := sb.String()
+    if !strings.Contains(out, "req-abc123") {
+        t.Fatalf("request id missing from debug output:\n%s", out)
+    }
+    for _, line := range strings.Split(out, "\n") {
+        if strings.Contains(line, "Z.AI SSE line") && !strings.Contains(line, "[req-abc123]") {
+            t.Fatalf("SSE debug line without request id: %q", line)
+        }
+    }
+}
+
+// An empty request id keeps the legacy "[DEBUG]" prefix rather than emitting
+// empty brackets, so the no-id call sites (tests, direct callers) stay clean.
+func TestSSEDebugLinesLegacyPrefix(t *testing.T) {
+    origW := log.Writer()
+    origFlags := log.Flags()
+    defer log.SetOutput(origW)
+    defer log.SetFlags(origFlags)
+
+    var sb strings.Builder
+    log.SetOutput(&sb)
+    log.SetFlags(0)
+
+    ch := make(chan ZAIResult, 16)
+    body := "data: {\"data\":{\"delta_content\":\"hi\"}}\n\ndata: [DONE]\n\n"
+    err := streamSSEResponse(strings.NewReader(body), ch, "")
+    close(ch)
+    if err != nil {
+        t.Fatalf("streamSSEResponse: %v", err)
+    }
+    for range ch {
+    }
+
+    if strings.Contains(sb.String(), "[]") {
+        t.Fatalf("empty id produced empty brackets: %q", sb.String())
+    }
+    if !strings.Contains(sb.String(), "[DEBUG]") {
+        t.Fatalf("legacy [DEBUG] prefix lost: %q", sb.String())
+    }
+}

--- a/internal/zbridge/types.go
+++ b/internal/zbridge/types.go
@@ -63,6 +63,11 @@ type SendOptions struct {
     // attach to the upstream completion request as the top-level "files"
     // array. Empty for text-only requests (field then stays out of the body).
     Files []map[string]interface{}
+    // RequestID carries the handler-generated client-visible request id, so
+    // debug log lines emitted while the upstream SSE stream is parsed can be
+    // attributed to their request when several are in flight (issue #36).
+    // Purely local: never reaches the upstream payload.
+    RequestID string
 }
 
 type ResponseResult struct {

--- a/internal/zbridge/zai.go
+++ b/internal/zbridge/zai.go
@@ -358,6 +358,7 @@ func sendToZAI(prompt string, opts SendOptions) (<-chan ZAIResult, error) {
         Messages          []Message
         ClientMessagesRaw json.RawMessage
         Files             []map[string]interface{}
+        RequestID         string
     }{
         Model:             model,
         ChatID:            chatID,
@@ -365,6 +366,7 @@ func sendToZAI(prompt string, opts SendOptions) (<-chan ZAIResult, error) {
         Messages:          messages,
         ClientMessagesRaw: opts.ClientMessagesRaw,
         Files:             opts.Files,
+        RequestID:         opts.RequestID,
     }
 
     ch := make(chan ZAIResult, 100)
@@ -384,6 +386,7 @@ func sendToZAIStream(prompt string, opts struct {
     Messages          []Message
     ClientMessagesRaw json.RawMessage
     Files             []map[string]interface{}
+    RequestID         string
 }, ch chan<- ZAIResult) error {
 
     for attempt := 0; attempt < 2; attempt++ {
@@ -510,7 +513,7 @@ func sendToZAIStream(prompt string, opts struct {
             return fmt.Errorf("Z.AI error %d: %s", resp.StatusCode, string(errBody))
         }
 
-        err = streamSSEResponse(resp.Body, ch)
+        err = streamSSEResponse(resp.Body, ch, opts.RequestID)
         resp.Body.Close()
         cancel()
         return err
@@ -761,9 +764,19 @@ func splitDetails(raw string) (reasoning, content string) {
     return rb.String(), cb.String()
 }
 
-func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
+// streamSSEResponse parses Z.AI's upstream SSE stream into ZAIResult chunks.
+// requestId, when non-empty, prefixes every debug log line emitted here so
+// concurrent streams can be attributed (issue #36).
+func streamSSEResponse(body io.Reader, ch chan<- ZAIResult, requestId string) error {
     scanner := bufio.NewScanner(body)
     scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+    // logPrefix labels debug output for this request. The client-visible id
+    // already exists, so the label is exactly what a log reader greps for.
+    logPrefix := "[DEBUG]"
+    if requestId != "" {
+        logPrefix = "[DEBUG] [" + requestId + "]"
+    }
 
     // ── Accumulated state across SSE lines ──
     var fullText strings.Builder      // raw upstream content, verbatim
@@ -844,7 +857,7 @@ func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
         trimmed := strings.TrimSpace(line)
 
         if config.Logging.Level == "debug" && trimmed != "" {
-            log.Println("[DEBUG] Z.AI SSE line:", trimmed)
+            log.Println(logPrefix, "Z.AI SSE line:", trimmed)
         }
 
         if !strings.HasPrefix(trimmed, "data: ") {
@@ -859,7 +872,7 @@ func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
         var j map[string]interface{}
         if err := json.Unmarshal([]byte(dataStr), &j); err != nil {
             if config.Logging.Level == "debug" {
-                log.Println("[DEBUG] Z.AI failed to parse SSE:", dataStr)
+                log.Println(logPrefix, "Z.AI failed to parse SSE:", dataStr)
             }
             continue
         }
@@ -867,7 +880,7 @@ func streamSSEResponse(body io.Reader, ch chan<- ZAIResult) error {
         // ── Detect inline errors (HTTP 200 with error in body) ──
         if errDetail := extractZAIError(j); errDetail != "" {
             if config.Logging.Level == "debug" {
-                log.Println("[DEBUG] Z.AI inline SSE error:", errDetail)
+                log.Println(logPrefix, "Z.AI inline SSE error:", errDetail)
             }
             return fmt.Errorf("Z.AI error: %s", errDetail)
         }


### PR DESCRIPTION
Closes #36.

## Problem

`LOG_LEVEL=debug` prints every upstream SSE line, but the lines carry no request identifier. With more than one request in flight the lines interleave in the log and cannot be attributed — #36 documents exactly how that poisons `edit_content` analysis (two prompts' deltas folded into what looked like one clean stream).

## Change

The handlers already generate a client-visible request id, so it now rides along with the request instead of living only in the handler:

- `SendOptions.RequestID` — new field, documented as purely local (never reaches the upstream payload)
- threaded `sendToZAI` → `sendToZAIStream` → `streamSSEResponse`
- the debug lines inside the SSE parser are prefixed with it:

```
[DEBUG] [req-abc123] Z.AI SSE line: data: {...}
```

The prefix applies to all three debug sites in the parser (SSE line, failed-parse, inline error). An empty id keeps the legacy `[DEBUG]` prefix, so direct callers (tests, any future seam) log exactly as before — no empty brackets.

## Notes

- No behaviour change beyond logging; the id never leaves the process.
- 4-space indent, matching `internal/zbridge` convention.

## Tests

- `TestSSEDebugLinesCarryRequestId` — captures the log while the real parser runs a synthetic body, asserts the id prefixes every SSE debug line
- `TestSSEDebugLinesLegacyPrefix` — empty id keeps `[DEBUG]` and emits no `[]`
- full suite green: `go build ./...`, `go vet ./...`, `go test ./...` (whitebox + blackbox)
