### PR TITLE
fix(agent): recognise tool calls written with no envelope at all (rebase of #35)

### DIFF
--- a/internal/zbridge/agent.go
+++ b/internal/zbridge/agent.go
@@ -982,6 +982,12 @@ type AgentStreamInterceptor struct {
     callIndex  int
     pendingSep bool // a tool-call block just closed: watch for a stray fence
 
+    // Declared tool names, so an envelope-less invocation can be told from
+    // prose that merely looks like one (see agent_bare.go). Empty disables
+    // that recognition entirely.
+    toolNames []string
+    bareKeep  int // hold-back floor covering the longest name plus its bracket
+
     // ── incremental tool-call streaming state ──
     inCall         bool   // between the opening and closing markers
     tcBlockStart   int    // offset of the opening marker (for leak-as-content)
@@ -1231,6 +1237,16 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
 
         rest := in.buffer[in.offset:]
         start, markerLen := findAgentMarker(rest, agentStartWord, final)
+        nativeStart := strings.Index(rest, nativeToolOpen)
+        // A call written with no envelope at all, neither the canonical
+        // markers nor Zhipu's <tool_call> tags, would otherwise reach the
+        // client as assistant text.
+        if handled, done := in.drainBareCall(rest, start, nativeStart, final, &content, &toolCalls); handled {
+            if done {
+                continue
+            }
+            break
+        }
         // Zhipu's native <tool_call> syntax streams as plain text and would
         // otherwise reach the client verbatim.
         if handled, done := in.drainNativeBlock(rest, start, final, &content, &toolCalls); handled {
@@ -1255,7 +1271,10 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
             // backed up to a rune boundary so a multi-byte character is
             // never split across emissions (invalid UTF-8 would render as
             // replacement-char garble on the client — issue #23).
-            const keep = agentStreamKeep
+            keep := agentStreamKeep
+            if in.bareKeep > keep {
+                keep = in.bareKeep
+            }
             if len(rest) > keep {
                 cut := len(rest) - keep
                 for cut > 0 && !utf8.RuneStart(rest[cut]) {
@@ -1571,19 +1590,22 @@ func agentTransformMessages(rawMessages, toolsRaw json.RawMessage) ([]byte, erro
 }
 
 // agentExtractToolCalls parses tool-call blocks out of finished assistant text
-// using the active shim's parser.
-func agentExtractToolCalls(text string) []map[string]interface{} {
+// using the active shim's parser. toolNames, when given, additionally allows
+// an envelope-less invocation of a declared tool to be recognised.
+func agentExtractToolCalls(text string, toolNames ...string) []map[string]interface{} {
     if config.agentModern() {
-        return ParseAgentToolCalls(text)
+        return ParseAgentToolCalls(TranslateBareToolCalls(text, toolNames))
     }
     return extractAgentToolCalls(text)
 }
 
 // agentStripToolCalls removes tool-call blocks from finished assistant text
-// using the active shim's stripper.
-func agentStripToolCalls(text string) string {
+// using the active shim's stripper. It must be given the same toolNames as
+// agentExtractToolCalls, or a recognised bare call would be reported and then
+// left in the content as well.
+func agentStripToolCalls(text string, toolNames ...string) string {
     if config.agentModern() {
-        return StripAgentToolCalls(text)
+        return StripAgentToolCalls(TranslateBareToolCalls(text, toolNames))
     }
     return stripAgentToolCallBlocks(text)
 }
@@ -1626,11 +1648,25 @@ func (l *legacyAgentInterceptor) finish() (string, []map[string]interface{}) {
 }
 
 // newAgentInterceptor constructs the streaming interceptor for the active shim.
-func newAgentInterceptor() agentInterceptor {
+func newAgentInterceptor(toolNames []string) agentInterceptor {
     if config.agentModern() {
-        return &modernAgentInterceptor{in: &AgentStreamInterceptor{}}
+        in := &AgentStreamInterceptor{}
+        in.setToolNames(toolNames)
+        return &modernAgentInterceptor{in: in}
     }
+    // The legacy shim has its own parser and its own block syntax; bare-call
+    // recognition is a modern-shim concern only.
     return &legacyAgentInterceptor{in: newAgentStreamInterceptor()}
+}
+
+// setToolNames records the request's declared tools and sizes the hold-back
+// window so a tool name split across upstream chunks is never flushed as
+// content before its opening bracket arrives.
+func (in *AgentStreamInterceptor) setToolNames(names []string) {
+    in.toolNames = names
+    if n := agentLongestName(names); n > 0 {
+        in.bareKeep = n + 2
+    }
 }
 
 // rearmAgentInterceptor replaces a stale interceptor (an upstream
@@ -1639,7 +1675,11 @@ func newAgentInterceptor() agentInterceptor {
 // before the rewind keeps its index, and the re-emitted block takes the
 // next one instead of colliding inside SDK accumulation.
 func rearmAgentInterceptor(old agentInterceptor) agentInterceptor {
-    fresh := newAgentInterceptor()
+    var names []string
+    if o, ok := old.(*modernAgentInterceptor); ok {
+        names = o.in.toolNames
+    }
+    fresh := newAgentInterceptor(names)
     switch o := old.(type) {
     case *modernAgentInterceptor:
         if f, ok := fresh.(*modernAgentInterceptor); ok {

--- a/internal/zbridge/agent.go
+++ b/internal/zbridge/agent.go
@@ -988,6 +988,22 @@ type AgentStreamInterceptor struct {
     toolNames []string
     bareKeep  int // hold-back floor covering the longest name plus its bracket
 
+    // bareFenceOpen tracks, for the bare-call recognizer only, whether the
+    // model's output is currently inside an open ``` markdown fence: a
+    // declared-tool invocation that is merely a documentation example inside
+    // a fence must not be mistaken for a real call (see agent_bare.go).
+    //
+    // This is state about the stream as a whole, not a value re-derived from
+    // whatever is left in the buffer: a fence opened in text already
+    // committed to the client (or consumed as part of an earlier bare call)
+    // is invisible to any scan that only looks at what has not yet been
+    // sent, so it must be threaded forward explicitly. It is updated in
+    // exactly two places — commitContent, for ordinary text, and the
+    // successful branch of drainBareCall, for a recognised call's own span —
+    // and must be carried across rearmAgentInterceptor (see there) or a
+    // mid-stream rewind silently forgets it.
+    bareFenceOpen bool
+
     // ── incremental tool-call streaming state ──
     inCall         bool   // between the opening and closing markers
     tcBlockStart   int    // offset of the opening marker (for leak-as-content)
@@ -1259,7 +1275,7 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
             if final {
                 // End of data: everything left is ordinary content.
                 if rest != "" {
-                    content = append(content, rest)
+                    in.commitContent(rest, &content)
                     in.offset = len(in.buffer)
                 }
                 break
@@ -1281,7 +1297,7 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
                     cut--
                 }
                 if cut > 0 {
-                    content = append(content, rest[:cut])
+                    in.commitContent(rest[:cut], &content)
                     in.offset += cut
                 }
             }
@@ -1290,7 +1306,7 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
         if start > 0 {
             piece := TrimTrailingAgentFence(rest[:start])
             if piece != "" {
-                content = append(content, piece)
+                in.commitContent(piece, &content)
             }
             in.offset += start
         }
@@ -1368,7 +1384,7 @@ func (in *AgentStreamInterceptor) drainToolCall(final bool, content *[]string, t
                 in.callIndex++
             } else {
                 // invalid model block: leave it as visible text
-                *content = append(*content, in.buffer[in.tcBlockStart:end+markerLen])
+                in.commitContent(in.buffer[in.tcBlockStart:end+markerLen], content)
             }
             in.offset = end + markerLen
             in.finishCall()
@@ -1674,16 +1690,27 @@ func (in *AgentStreamInterceptor) setToolNames(names []string) {
 // while preserving the client-visible call-index sequence: a call streamed
 // before the rewind keeps its index, and the re-emitted block takes the
 // next one instead of colliding inside SDK accumulation.
+//
+// It also preserves bareFenceOpen. Without this, a rewind landing while the
+// model's output is mid-way through a ``` fence resets the fresh
+// interceptor to "not in a fence", and a bare-call example inside that same
+// fence — the exact false positive the fence check exists to catch — is
+// misread as a real call again, only now intermittently and after the
+// stream has already been rewound once, which is harder to reproduce than
+// the original report.
 func rearmAgentInterceptor(old agentInterceptor) agentInterceptor {
     var names []string
+    var fenceOpen bool
     if o, ok := old.(*modernAgentInterceptor); ok {
         names = o.in.toolNames
+        fenceOpen = o.in.bareFenceOpen
     }
     fresh := newAgentInterceptor(names)
     switch o := old.(type) {
     case *modernAgentInterceptor:
         if f, ok := fresh.(*modernAgentInterceptor); ok {
             f.in.callIndex = o.in.callIndex
+            f.in.bareFenceOpen = fenceOpen
         }
     case *legacyAgentInterceptor:
         if f, ok := fresh.(*legacyAgentInterceptor); ok {

--- a/internal/zbridge/agent_bare.go
+++ b/internal/zbridge/agent_bare.go
@@ -81,61 +81,177 @@ func atLineStart(s string, i int, prevByte byte) bool {
     return prevByte == 0 || prevByte == '\n' || prevByte == '\r'
 }
 
-// findBareCall returns the first envelope-less invocation of a declared tool
-// in s. complete is false when an invocation starts but its argument list has
-// not closed yet. The caller must then hold the text back rather than emit
-// it, because the rest of the call is still arriving.
-func findBareCall(s string, names []string, prevByte byte) (call bareCall, found, complete bool) {
-    if len(names) == 0 {
-        return bareCall{}, false, false
+// fenceDelimLine reports whether line is a markdown code-fence delimiter:
+// optional leading horizontal whitespace followed by at least three
+// backticks. Both the opening line (which may carry a language tag after the
+// backticks, e.g. "```go") and the closing line (bare backticks) match — a
+// fence toggles either way.
+//
+// This deliberately does not implement the rest of CommonMark's fence rules
+// (matching backtick/tilde counts, ~~~ fences, 4-space indented code blocks).
+// Every model capture examined for this fix used plain ``` fences; extending
+// coverage to those forms is a separate, larger change and is out of scope
+// here — see the PR description for the reasoning.
+func fenceDelimLine(line string) bool {
+    return strings.HasPrefix(strings.TrimLeft(line, " \t"), "```")
+}
+
+// advanceFenceState folds free text s into the running markdown-fence state,
+// toggling once per fence-delimiter line (see fenceDelimLine). open is the
+// state entering s; the return value is the state after it.
+//
+// Callers must use this — never re-derive fence state from a suffix window
+// of the stream — because a fence opened in text already committed to the
+// client is invisible to any later scan that only looks at what has not yet
+// been sent.
+func advanceFenceState(s string, open bool) bool {
+    for len(s) > 0 {
+        nl := strings.IndexByte(s, '\n')
+        var line string
+        if nl < 0 {
+            line, s = s, ""
+        } else {
+            line, s = s[:nl], s[nl+1:]
+        }
+        if fenceDelimLine(line) {
+            open = !open
+        }
     }
-    best := -1
-    var bestName string
-    for _, name := range names {
-        for pos := 0; ; {
-            idx := strings.Index(s[pos:], name)
-            if idx < 0 {
-                break
+    return open
+}
+
+// advanceFenceStateOverCall folds one complete bare-call span (name through
+// its closing bracket, as returned by findBareCall) into the running fence
+// state. It mirrors bareArgsEnd's own quote/escape tracking so the two can
+// never disagree about where a quoted argument value starts or ends: a ```
+// sequence inside a quoted value is argument data, not a markdown fence, and
+// must not toggle the state — see the PR description for a live example
+// (a heredoc-style shell command whose payload contains a fenced code
+// block). Only backticks in the unquoted parts of the call (which is
+// realistically just the name and the bracket/comma/key structure) can ever
+// toggle it.
+func advanceFenceStateOverCall(call string, open bool) bool {
+    var quote byte
+    lineStart := 0
+    for i := 0; i < len(call); i++ {
+        c := call[i]
+        if quote != 0 {
+            switch c {
+            case '\\':
+                i++
+            case quote:
+                quote = 0
             }
-            at := pos + idx
-            pos = at + 1
-            after := at + len(name)
-            if after >= len(s) {
-                // The name ends the text; its delimiter has not arrived.
-                if atLineStart(s, at, prevByte) && (best < 0 || at < best) {
+            continue
+        }
+        switch c {
+        case '"', '\'':
+            quote = c
+        case '\n':
+            if fenceDelimLine(call[lineStart:i]) {
+                open = !open
+            }
+            lineStart = i + 1
+        }
+    }
+    if fenceDelimLine(call[lineStart:]) {
+        open = !open
+    }
+    return open
+}
+
+// findBareCall returns the first envelope-less invocation of a declared tool
+// in s that is not sitting inside an open ``` fence — a fenced occurrence is
+// a documentation example, not a call, so it is skipped and the search
+// continues past it (a real call may still follow once the fence closes).
+//
+// fenceOpen is the fence state immediately before s. fenceAfter is that same
+// state immediately after the returned call, or after all of s when no call
+// is found or the trailing one is still incomplete; callers MUST carry it
+// forward as the next call's fenceOpen rather than recomputing it from a
+// shorter window (see advanceFenceState's doc comment for why).
+//
+// complete is false when an invocation starts but its argument list has not
+// closed yet. The caller must then hold the text back rather than emit it,
+// because the rest of the call is still arriving.
+func findBareCall(s string, names []string, prevByte byte, fenceOpen bool) (call bareCall, found, complete bool, fenceAfter bool) {
+    if len(names) == 0 {
+        return bareCall{}, false, false, fenceOpen
+    }
+    scanned := 0 // s[:scanned] has already been folded into state
+    searchFrom := 0
+    state := fenceOpen
+    for {
+        best := -1
+        var bestName string
+        for _, name := range names {
+            for pos := searchFrom; ; {
+                idx := strings.Index(s[pos:], name)
+                if idx < 0 {
+                    break
+                }
+                at := pos + idx
+                pos = at + 1
+                after := at + len(name)
+                if after >= len(s) {
+                    // The name ends the text; its delimiter has not arrived.
+                    if atLineStart(s, at, prevByte) && (best < 0 || at < best) {
+                        best, bestName = at, name
+                    }
+                    break
+                }
+                if s[after] != '(' && s[after] != '{' {
+                    continue
+                }
+                if !atLineStart(s, at, prevByte) {
+                    continue
+                }
+                if best < 0 || at < best {
                     best, bestName = at, name
                 }
                 break
             }
-            if s[after] != '(' && s[after] != '{' {
-                continue
-            }
-            if !atLineStart(s, at, prevByte) {
-                continue
-            }
-            if best < 0 || at < best {
-                best, bestName = at, name
-            }
-            break
         }
+        if best < 0 {
+            return bareCall{}, false, false, advanceFenceState(s[scanned:], state)
+        }
+
+        // Fold the free text between the previous scan point and this
+        // candidate before judging it, then advance the scan point so the
+        // same bytes are never folded twice across loop iterations.
+        state = advanceFenceState(s[scanned:best], state)
+        scanned = best
+
+        if state {
+            // Inside an open fence: a documentation example, not a call.
+            // Skip past this occurrence and keep looking.
+            searchFrom = best + len(bestName)
+            continue
+        }
+
+        open := best + len(bestName)
+        if open >= len(s) {
+            return bareCall{start: best, name: bestName}, true, false, state
+        }
+        end, closed := bareArgsEnd(s, open)
+        if !closed {
+            return bareCall{start: best, name: bestName}, true, false, state
+        }
+        args, ok := parseBareArgs(s[open:end])
+        if !ok {
+            // Complete but unreadable: not a call we can build, leave it as
+            // text (matches the pre-fence-awareness behaviour of giving up
+            // on this scan entirely rather than guessing past a malformed
+            // call).
+            return bareCall{}, false, false, state
+        }
+        // The call span itself is never emitted as content — it becomes a
+        // tool_call — but it still occupies space in the model's output, so
+        // backticks inside it (outside any quoted value) still affect what
+        // a later scan on this stream sees.
+        fenceAfter = advanceFenceStateOverCall(s[best:end], state)
+        return bareCall{start: best, end: end, name: bestName, args: args}, true, true, fenceAfter
     }
-    if best < 0 {
-        return bareCall{}, false, false
-    }
-    open := best + len(bestName)
-    if open >= len(s) {
-        return bareCall{start: best, name: bestName}, true, false
-    }
-    end, closed := bareArgsEnd(s, open)
-    if !closed {
-        return bareCall{start: best, name: bestName}, true, false
-    }
-    args, ok := parseBareArgs(s[open:end])
-    if !ok {
-        // Complete but unreadable: not a call we can build, leave it as text.
-        return bareCall{}, false, false
-    }
-    return bareCall{start: best, end: end, name: bestName, args: args}, true, true
 }
 
 // bareArgsEnd finds the index just past the argument list that opens at
@@ -203,9 +319,10 @@ func TranslateBareToolCalls(text string, names []string) string {
     var b strings.Builder
     rest := text
     var prev byte
+    fenceOpen := false
     changed := false
     for {
-        call, found, complete := findBareCall(rest, names, prev)
+        call, found, complete, fenceAfter := findBareCall(rest, names, prev, fenceOpen)
         if !found || !complete {
             b.WriteString(rest)
             break
@@ -218,6 +335,7 @@ func TranslateBareToolCalls(text string, names []string) string {
         b.WriteString(rest[:call.start])
         b.WriteString(agentToolStart + string(encoded) + agentToolEnd)
         changed = true
+        fenceOpen = fenceAfter
         if call.end > 0 {
             prev = rest[call.end-1]
         }
@@ -227,6 +345,23 @@ func TranslateBareToolCalls(text string, names []string) string {
         return text
     }
     return b.String()
+}
+
+// commitContent appends s to content and folds it into the interceptor's
+// running bare-call fence state (in.bareFenceOpen — see its doc comment on
+// AgentStreamInterceptor). This is the ONLY place that state may change for
+// ordinary text: every append to *content anywhere in this package's drain
+// path must go through here rather than appending directly, or the fence
+// state silently desyncs from what the client actually receives and the
+// false-positive this file exists to prevent can resurface. s is assumed to
+// be free text, not the span of a recognised call — see
+// advanceFenceStateOverCall for that case.
+func (in *AgentStreamInterceptor) commitContent(s string, content *[]string) {
+    if s == "" {
+        return
+    }
+    *content = append(*content, s)
+    in.bareFenceOpen = advanceFenceState(s, in.bareFenceOpen)
 }
 
 // drainBareCall handles an envelope-less invocation met while streaming. It
@@ -245,12 +380,18 @@ func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nat
     if in.offset > 0 {
         prev = in.buffer[in.offset-1]
     }
-    call, found, complete := findBareCall(rest, in.toolNames, prev)
+    call, found, complete, fenceAfter := findBareCall(rest, in.toolNames, prev, in.bareFenceOpen)
     if !found {
+        // All of rest was free text as far as bare-call scanning goes, but
+        // it may not all be committed this pass (the general hold-back path
+        // further down in drain() may keep a tail). Do not fold it here —
+        // whatever actually gets committed will be folded through
+        // commitContent at the point it is committed.
         return false, false
     }
     // Either envelope wins when it starts at or before this point: both are
-    // explicit, and the canonical one streams properly.
+    // explicit, and the canonical one streams properly. Leave in.bareFenceOpen
+    // untouched — the winning path commits its own preceding text.
     if canonicalStart >= 0 && canonicalStart <= call.start {
         return false, false
     }
@@ -264,7 +405,7 @@ func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nat
             return false, false
         }
         if call.start > 0 {
-            *content = append(*content, rest[:call.start])
+            in.commitContent(rest[:call.start], content)
             in.offset += call.start
         }
         return true, false
@@ -274,9 +415,13 @@ func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nat
         return false, false
     }
     if call.start > 0 {
-        *content = append(*content, rest[:call.start])
+        in.commitContent(rest[:call.start], content)
     }
     *toolCalls = append(*toolCalls, ParseAgentToolCalls(agentToolStart+string(encoded)+agentToolEnd)...)
+    // fenceAfter already accounts for both the leading text just committed
+    // above and the call span itself (see findBareCall) — this replaces,
+    // rather than adds to, whatever commitContent just set.
+    in.bareFenceOpen = fenceAfter
     in.offset += call.end
     in.pendingSep = true
     return true, true

--- a/internal/zbridge/agent_bare.go
+++ b/internal/zbridge/agent_bare.go
@@ -1,0 +1,283 @@
+package zbridge
+
+import (
+    "encoding/json"
+    "strings"
+)
+
+// Zhipu's models sometimes drop the envelope entirely and write the call as a
+// plain function invocation at the start of a line, most often right after a
+// </details> block closes:
+//
+//	</details>
+//	bash(i="Inspecting the upstream commit", command="git -C ../repo show --stat")
+//
+// Neither the canonical <<<TOOL_CALL>>> markers nor Zhipu's own <tool_call>
+// tags are present, so nothing downstream recognises it and the line reaches
+// the client as assistant text. Captured live: one stream in five took this
+// shape while the other four used the canonical markers.
+//
+// Recognising a bare call is only safe because the request declares its tools.
+// `grep(pattern="x")` in prose is indistinguishable from a call by shape
+// alone, so the name is required to match a declared tool, the invocation
+// must start a line, and its argument list must be complete and parseable.
+// Without a tool list nothing here fires at all.
+
+// agentToolNames extracts the declared function names from an OpenAI-format
+// tools array. Order is preserved; malformed entries are skipped.
+func agentToolNames(raw json.RawMessage) []string {
+    if len(raw) == 0 {
+        return nil
+    }
+    var tools []struct {
+        Function struct {
+            Name string `json:"name"`
+        } `json:"function"`
+    }
+    if json.Unmarshal(raw, &tools) != nil {
+        return nil
+    }
+    var names []string
+    for _, t := range tools {
+        if t.Function.Name != "" {
+            names = append(names, t.Function.Name)
+        }
+    }
+    return names
+}
+
+// agentLongestName reports the longest declared tool name, used to size the
+// streaming hold-back window so a name split across chunks is never flushed
+// as content before its opening parenthesis arrives.
+func agentLongestName(names []string) int {
+    longest := 0
+    for _, n := range names {
+        if len(n) > longest {
+            longest = len(n)
+        }
+    }
+    return longest
+}
+
+// bareCall describes one envelope-less invocation found in a text.
+type bareCall struct {
+    start, end int
+    name       string
+    args       map[string]interface{}
+}
+
+// atLineStart reports whether index i begins a line in s, ignoring horizontal
+// whitespace. prevByte is the byte immediately before s when s is a slice of a
+// larger buffer (0 when s starts the buffer).
+func atLineStart(s string, i int, prevByte byte) bool {
+    for i > 0 {
+        c := s[i-1]
+        if c == ' ' || c == '\t' {
+            i--
+            continue
+        }
+        return c == '\n' || c == '\r'
+    }
+    return prevByte == 0 || prevByte == '\n' || prevByte == '\r'
+}
+
+// findBareCall returns the first envelope-less invocation of a declared tool
+// in s. complete is false when an invocation starts but its argument list has
+// not closed yet. The caller must then hold the text back rather than emit
+// it, because the rest of the call is still arriving.
+func findBareCall(s string, names []string, prevByte byte) (call bareCall, found, complete bool) {
+    if len(names) == 0 {
+        return bareCall{}, false, false
+    }
+    best := -1
+    var bestName string
+    for _, name := range names {
+        for pos := 0; ; {
+            idx := strings.Index(s[pos:], name)
+            if idx < 0 {
+                break
+            }
+            at := pos + idx
+            pos = at + 1
+            after := at + len(name)
+            if after >= len(s) {
+                // The name ends the text; its delimiter has not arrived.
+                if atLineStart(s, at, prevByte) && (best < 0 || at < best) {
+                    best, bestName = at, name
+                }
+                break
+            }
+            if s[after] != '(' && s[after] != '{' {
+                continue
+            }
+            if !atLineStart(s, at, prevByte) {
+                continue
+            }
+            if best < 0 || at < best {
+                best, bestName = at, name
+            }
+            break
+        }
+    }
+    if best < 0 {
+        return bareCall{}, false, false
+    }
+    open := best + len(bestName)
+    if open >= len(s) {
+        return bareCall{start: best, name: bestName}, true, false
+    }
+    end, closed := bareArgsEnd(s, open)
+    if !closed {
+        return bareCall{start: best, name: bestName}, true, false
+    }
+    args, ok := parseBareArgs(s[open:end])
+    if !ok {
+        // Complete but unreadable: not a call we can build, leave it as text.
+        return bareCall{}, false, false
+    }
+    return bareCall{start: best, end: end, name: bestName, args: args}, true, true
+}
+
+// bareArgsEnd finds the index just past the argument list that opens at
+// index open, honouring quotes and escapes so a bracket inside a string does
+// not close it.
+func bareArgsEnd(s string, open int) (int, bool) {
+    var closer byte
+    switch s[open] {
+    case '(':
+        closer = ')'
+    case '{':
+        closer = '}'
+    default:
+        return 0, false
+    }
+    opener := s[open]
+    depth := 0
+    var quote byte
+    for i := open; i < len(s); i++ {
+        c := s[i]
+        if quote != 0 {
+            switch c {
+            case '\\':
+                i++
+            case quote:
+                quote = 0
+            }
+            continue
+        }
+        switch c {
+        case '"', '\'':
+            quote = c
+        case opener:
+            depth++
+        case closer:
+            depth--
+            if depth == 0 {
+                return i + 1, true
+            }
+        }
+    }
+    return 0, false
+}
+
+// parseBareArgs reads either argument form a bare call may carry.
+func parseBareArgs(payload string) (map[string]interface{}, bool) {
+    trimmed := strings.TrimSpace(payload)
+    if strings.HasPrefix(trimmed, "{") {
+        var obj map[string]interface{}
+        if json.Unmarshal([]byte(trimmed), &obj) != nil {
+            return nil, false
+        }
+        return obj, true
+    }
+    return parseNativeKwargs(trimmed)
+}
+
+// TranslateBareToolCalls rewrites every envelope-less invocation of a declared
+// tool into the canonical marker form. Without a tool list, or without a
+// complete invocation, the text is returned unchanged.
+func TranslateBareToolCalls(text string, names []string) string {
+    if len(names) == 0 {
+        return text
+    }
+    var b strings.Builder
+    rest := text
+    var prev byte
+    changed := false
+    for {
+        call, found, complete := findBareCall(rest, names, prev)
+        if !found || !complete {
+            b.WriteString(rest)
+            break
+        }
+        encoded, err := json.Marshal(map[string]interface{}{"name": call.name, "arguments": call.args})
+        if err != nil {
+            b.WriteString(rest)
+            break
+        }
+        b.WriteString(rest[:call.start])
+        b.WriteString(agentToolStart + string(encoded) + agentToolEnd)
+        changed = true
+        if call.end > 0 {
+            prev = rest[call.end-1]
+        }
+        rest = rest[call.end:]
+    }
+    if !changed {
+        return text
+    }
+    return b.String()
+}
+
+// drainBareCall handles an envelope-less invocation met while streaming. It
+// mirrors drainNativeBlock: the call is buffered whole, because its payload is
+// not JSON and the incremental scanner cannot follow it.
+//
+// handled is false when the caller should continue with the other scans. When
+// handled is true, done reports whether the call was consumed (keep scanning)
+// or is still arriving (wait for more chunks).
+func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nativeStart int, final bool,
+    content *[]string, toolCalls *[]map[string]interface{}) (handled, done bool) {
+    if len(in.toolNames) == 0 {
+        return false, false
+    }
+    var prev byte
+    if in.offset > 0 {
+        prev = in.buffer[in.offset-1]
+    }
+    call, found, complete := findBareCall(rest, in.toolNames, prev)
+    if !found {
+        return false, false
+    }
+    // Either envelope wins when it starts at or before this point: both are
+    // explicit, and the canonical one streams properly.
+    if canonicalStart >= 0 && canonicalStart <= call.start {
+        return false, false
+    }
+    if nativeStart >= 0 && nativeStart <= call.start {
+        return false, false
+    }
+    if !complete {
+        if final {
+            // The argument list never closed. Treat it as prose rather than
+            // inventing a call from a half-written one.
+            return false, false
+        }
+        if call.start > 0 {
+            *content = append(*content, rest[:call.start])
+            in.offset += call.start
+        }
+        return true, false
+    }
+    encoded, err := json.Marshal(map[string]interface{}{"name": call.name, "arguments": call.args})
+    if err != nil {
+        return false, false
+    }
+    if call.start > 0 {
+        *content = append(*content, rest[:call.start])
+    }
+    *toolCalls = append(*toolCalls, ParseAgentToolCalls(agentToolStart+string(encoded)+agentToolEnd)...)
+    in.offset += call.end
+    in.pendingSep = true
+    return true, true
+}

--- a/internal/zbridge/agent_bare_test.go
+++ b/internal/zbridge/agent_bare_test.go
@@ -1,0 +1,286 @@
+package zbridge
+
+import (
+    "strconv"
+    "encoding/json"
+    "strings"
+    "testing"
+)
+
+// Captured live from LOG_LEVEL=debug: glm-5.3 closed its <details> block and
+// wrote the call straight into the answer with no envelope at all. One stream
+// in five took this shape; the other four used the canonical markers.
+const bareCapture = "\nbash(i=\"Inspecting today's upstream commit for overlap with local patches\", " +
+    "command=\"git -C ../aistudio2api show --stat --oneline origin/main | head -30\")"
+
+var bareTools = []string{"bash", "read_file"}
+
+func bareCalls(t *testing.T, text string, names []string) []map[string]interface{} {
+    t.Helper()
+    return ParseAgentToolCalls(TranslateBareToolCalls(text, names))
+}
+
+func bareArgs(t *testing.T, call map[string]interface{}) map[string]interface{} {
+    t.Helper()
+    fn := call["function"].(map[string]interface{})
+    var args map[string]interface{}
+    if err := json.Unmarshal([]byte(fn["arguments"].(string)), &args); err != nil {
+        t.Fatalf("arguments are not valid JSON: %v", err)
+    }
+    return args
+}
+
+func TestBareCallFromLiveCapture(t *testing.T) {
+    calls := bareCalls(t, "Ich sehe nach.\n"+bareCapture, bareTools)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 tool call, got %d", len(calls))
+    }
+    fn := calls[0]["function"].(map[string]interface{})
+    if fn["name"] != "bash" {
+        t.Fatalf("want name bash, got %v", fn["name"])
+    }
+    args := bareArgs(t, calls[0])
+    if args["command"] != "git -C ../aistudio2api show --stat --oneline origin/main | head -30" {
+        t.Fatalf("command lost: %#v", args["command"])
+    }
+    if args["i"] != "Inspecting today's upstream commit for overlap with local patches" {
+        t.Fatalf("intent lost: %#v", args["i"])
+    }
+    got := StripAgentToolCalls(TranslateBareToolCalls("Ich sehe nach.\n"+bareCapture, bareTools))
+    if strings.Contains(got, "bash(") {
+        t.Fatalf("call leaked into content: %q", got)
+    }
+    if !strings.Contains(got, "Ich sehe nach.") {
+        t.Fatalf("ordinary content lost: %q", got)
+    }
+}
+
+// The whole safety of this path is that the name must be one the request
+// declared. Prose that merely looks like a call must survive untouched.
+func TestBareCallRequiresDeclaredTool(t *testing.T) {
+    for _, names := range [][]string{nil, {}, {"read_file"}, {"web_search"}} {
+        if calls := bareCalls(t, bareCapture, names); len(calls) != 0 {
+            t.Fatalf("names %v: undeclared tool produced %d calls", names, len(calls))
+        }
+        if got := TranslateBareToolCalls(bareCapture, names); got != bareCapture {
+            t.Fatalf("names %v: text rewritten: %q", names, got)
+        }
+    }
+}
+
+func TestBareCallRequiresLineStart(t *testing.T) {
+    for _, prose := range []string{
+        `Du kannst bash(command="ls") benutzen, um das zu sehen.`,
+        "Der Aufruf ist dann bash(command=\"ls\").",
+        "`bash(command=\"ls\")` als Beispiel.",
+    } {
+        if calls := bareCalls(t, prose, bareTools); len(calls) != 0 {
+            t.Fatalf("prose %q produced %d calls", prose, len(calls))
+        }
+    }
+}
+
+// Leading indentation still counts as the start of a line: the models indent
+// the call under a list item often enough.
+func TestBareCallAllowsLeadingIndent(t *testing.T) {
+    if calls := bareCalls(t, "Schritt 1:\n    bash(command=\"ls\")", bareTools); len(calls) != 1 {
+        t.Fatalf("indented call not recognised: %d calls", len(calls))
+    }
+}
+
+// A call whose argument list never closes must stay text rather than become a
+// command the model never finished writing.
+func TestBareCallTruncatedStaysText(t *testing.T) {
+    for _, truncated := range []string{
+        "\nbash(command=\"rm -rf /home/finn/Proj",
+        "\nbash(command=\"ls\", cwd=",
+        "\nbash(",
+        "\nbash",
+    } {
+        if calls := bareCalls(t, truncated, bareTools); len(calls) != 0 {
+            t.Fatalf("truncated %q produced %d calls", truncated, len(calls))
+        }
+        if got := TranslateBareToolCalls(truncated, bareTools); got != truncated {
+            t.Fatalf("truncated %q rewritten: %q", truncated, got)
+        }
+    }
+}
+
+// Brackets and quotes inside the command must not end the argument list early.
+func TestBareCallNestedBrackets(t *testing.T) {
+    in := "\nbash(command=\"awk '{print $1}' f.txt | grep -E '(a|b)' \", i=\"filter\")"
+    calls := bareCalls(t, in, bareTools)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 call, got %d", len(calls))
+    }
+    if cmd := bareArgs(t, calls[0])["command"]; !strings.Contains(cmd.(string), "{print $1}") {
+        t.Fatalf("command truncated at a bracket: %q", cmd)
+    }
+}
+
+func TestBareCallJSONArguments(t *testing.T) {
+    calls := bareCalls(t, "\nbash{\"command\":\"ls -la\"}", bareTools)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 call, got %d", len(calls))
+    }
+    if bareArgs(t, calls[0])["command"] != "ls -la" {
+        t.Fatalf("JSON arguments lost")
+    }
+}
+
+// An explicit envelope always wins: it is the documented shape and it streams.
+func TestBareCallCanonicalWins(t *testing.T) {
+    in := agentToolStart + `{"name":"read_file","arguments":{"path":"a.txt"}}` + agentToolEnd +
+        "\nbash(command=\"ls\")"
+    calls := bareCalls(t, in, bareTools)
+    if len(calls) != 2 {
+        t.Fatalf("want 2 calls, got %d", len(calls))
+    }
+    if calls[0]["function"].(map[string]interface{})["name"] != "read_file" {
+        t.Fatalf("canonical block did not keep its place")
+    }
+}
+
+// ── streaming ────────────────────────────────────────────────────────────────
+
+func feedChunksTools(t *testing.T, names []string, chunks []string, step int) (string, int, string) {
+    t.Helper()
+    in := &AgentStreamInterceptor{}
+    in.setToolNames(names)
+    var b, acc strings.Builder
+    calls := 0
+    collect := func(parsed AgentParsedChunk) {
+        b.WriteString(parsed.Content)
+        for _, call := range parsed.ToolCalls {
+            if id, _ := call["id"].(string); id != "" {
+                calls++
+            }
+            fn := call["function"].(map[string]interface{})
+            frag, _ := fn["arguments"].(string)
+            acc.WriteString(frag)
+        }
+    }
+    for i := 0; i < len(chunks); i += step {
+        piece := ""
+        for j := i; j < i+step && j < len(chunks); j++ {
+            piece += chunks[j]
+        }
+        collect(in.Feed(piece))
+    }
+    collect(in.Finish())
+    return b.String(), calls, acc.String()
+}
+
+func TestStreamBareCall(t *testing.T) {
+    for _, size := range []int{1, 3, 7, 13, 64, 4096} {
+        content, calls, args := feedChunksTools(t, bareTools,
+            splitRunes("Ich sehe nach."+bareCapture, size), 1)
+        if calls != 1 {
+            t.Fatalf("size %d: want 1 call, got %d (content %q)", size, calls, content)
+        }
+        if !strings.Contains(args, "show --stat --oneline") {
+            t.Fatalf("size %d: arguments lost: %q", size, args)
+        }
+        if strings.Contains(content, "bash(") {
+            t.Fatalf("size %d: call leaked as content: %q", size, content)
+        }
+        if !strings.Contains(content, "Ich sehe nach.") {
+            t.Fatalf("size %d: ordinary content lost: %q", size, content)
+        }
+    }
+}
+
+// Without a tool list the streaming path must behave exactly as before.
+func TestStreamBareCallInertWithoutTools(t *testing.T) {
+    for _, size := range []int{1, 7, 4096} {
+        content, calls, _ := feedChunksTools(t, nil, splitRunes(bareCapture, size), 1)
+        if calls != 0 {
+            t.Fatalf("size %d: produced %d calls without a tool list", size, calls)
+        }
+        if !strings.Contains(content, "bash(") {
+            t.Fatalf("size %d: content swallowed: %q", size, content)
+        }
+    }
+}
+
+// A truncated call at end of stream must surface rather than vanish.
+func TestStreamBareCallTruncatedNotSwallowed(t *testing.T) {
+    content, calls, _ := feedChunksTools(t, bareTools,
+        splitRunes("prefix\nbash(command=\"git -C ../ai", 5), 1)
+    if calls != 0 {
+        t.Fatalf("truncated stream produced %d calls", calls)
+    }
+    if !strings.Contains(content, "prefix") {
+        t.Fatalf("content before the truncated call lost: %q", content)
+    }
+}
+
+// ── through the real SSE parser ──────────────────────────────────────────────
+
+// Shaped after a live LOG_LEVEL=debug capture: one SSE event ended with
+//
+//	…).\n</details>\nbash
+//
+// and the next carried `(i="…", command="git -C ../a`, with an edit_content
+// event completing the command afterwards. The name, the opening bracket and
+// the argument list therefore arrive in three separate upstream events, which
+// is what makes this worth running through streamSSEResponse rather than
+// asserting on a finished string.
+//
+// The events are synthetic: the captured log carries no request id, so lines
+// from concurrent requests cannot be separated with confidence. Their shape is
+// taken from the capture; their isolation is not.
+func TestBareCallThroughSSEPipeline(t *testing.T) {
+    quote := func(s string) string {
+        b, err := json.Marshal(s)
+        if err != nil {
+            t.Fatalf("marshal: %v", err)
+        }
+        return string(b)
+    }
+    part1 := "<details type=\"reasoning\" done=\"true\">\n> Checking the upstream commit.\n</details>\nbash"
+    part2 := "(i=\"Inspecting the upstream commit\", command=\"git -C ../a"
+    part3 := "istudio2api show --stat --oneline origin/main | head -30\")"
+
+    // part1+part2 is pure ASCII, so its UTF-16 length is its byte length.
+    editIndex := len(part1) + len(part2)
+
+    body := sseEvent(`{"type":"chat:completion","data":{"delta_content":`+quote(part1)+`,"phase":"answer"}}`) +
+        sseEvent(`{"type":"chat:completion","data":{"delta_content":`+quote(part2)+`,"phase":"answer"}}`) +
+        sseEvent(`{"type":"chat:completion","data":{"edit_index":`+itoa(editIndex)+`,"edit_content":`+quote(part3)+`,"phase":"other"}}`) +
+        sseEvent(`{"type":"chat:completion","data":{"phase":"done","done":true}}`)
+
+    in := &AgentStreamInterceptor{}
+    in.setToolNames([]string{"bash"})
+    var content, args strings.Builder
+    calls := 0
+    collect := func(p AgentParsedChunk) {
+        content.WriteString(p.Content)
+        for _, call := range p.ToolCalls {
+            if id, _ := call["id"].(string); id != "" {
+                calls++
+            }
+            fn := call["function"].(map[string]interface{})
+            frag, _ := fn["arguments"].(string)
+            args.WriteString(frag)
+        }
+    }
+    for _, r := range runSSEParser(t, body) {
+        if r.Chunk != "" {
+            collect(in.Feed(r.Chunk))
+        }
+    }
+    collect(in.Finish())
+
+    if calls != 1 {
+        t.Fatalf("want 1 tool call, got %d (content %q)", calls, content.String())
+    }
+    if !strings.Contains(args.String(), "show --stat --oneline origin/main") {
+        t.Fatalf("command lost across the edit event: %q", args.String())
+    }
+    if strings.Contains(content.String(), "bash(") {
+        t.Fatalf("call leaked as content: %q", content.String())
+    }
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }

--- a/internal/zbridge/agent_bare_test.go
+++ b/internal/zbridge/agent_bare_test.go
@@ -284,3 +284,133 @@ func TestBareCallThroughSSEPipeline(t *testing.T) {
 }
 
 func itoa(n int) string { return strconv.Itoa(n) }
+
+// ── fence-awareness (security boundary: doc examples must not fire) ─────────
+
+// A declared-tool invocation written purely as a documentation example
+// inside a fenced code block must stay text, in both argument forms. Without
+// fence-awareness, atLineStart + a declared name + complete arguments is
+// indistinguishable from a real call, so a model explaining its own tool
+// syntax could trigger a real invocation.
+func TestBareCallInsideFencedDocExample(t *testing.T) {
+    cases := []string{
+        "Example:\n```text\nweb_search{\"query\":\"hello\"}\n```\n",
+        "Example:\n```text\nweb_search(query=\"test\", limit=1)\n```\n",
+    }
+    names := []string{"web_search"}
+    for _, in := range cases {
+        if calls := bareCalls(t, in, names); len(calls) != 0 {
+            t.Fatalf("fenced example fired as a call: %q -> %d calls", in, len(calls))
+        }
+        if got := TranslateBareToolCalls(in, names); got != in {
+            t.Fatalf("fenced example rewritten: %q -> %q", in, got)
+        }
+    }
+}
+
+// A fenced example must not blind the parser to a real call in the same
+// message once the fence closes — skip the fenced candidate, keep scanning.
+func TestBareCallSkipsFencedThenFindsReal(t *testing.T) {
+    in := "Example:\n```text\nweb_search(query=\"documentation\")\n```\n" +
+        "\nweb_search(query=\"real\")"
+    names := []string{"web_search"}
+    calls := bareCalls(t, in, names)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 call (the one after the fence), got %d", len(calls))
+    }
+    if args := bareArgs(t, calls[0]); args["query"] != "real" {
+        t.Fatalf("wrong call fired: %#v", args)
+    }
+}
+
+// ── quoted-argument isolation (``` inside call data is not a fence) ─────────
+
+// A ``` sequence that is argument data — e.g. a heredoc payload for a real
+// shell call — must not be mistaken for a markdown fence. If it were, it
+// would flip in.bareFenceOpen and could make the genuinely real call right
+// after it register as "inside a fence" and get skipped.
+func TestBareCallBacktickInQuotedArgDoesNotToggleFence(t *testing.T) {
+    in := "bash(command=\"cat <<'EOF'\n```python\nprint('hi')\n```\nEOF\")\n" +
+        "\nweb_search(query=\"hello\")"
+    names := []string{"bash", "web_search"}
+    calls := bareCalls(t, in, names)
+    if len(calls) != 2 {
+        t.Fatalf("want 2 calls (bash and web_search), got %d: %#v", len(calls), calls)
+    }
+    if fn := calls[0]["function"].(map[string]interface{}); fn["name"] != "bash" {
+        t.Fatalf("first call = %v, want bash", fn["name"])
+    }
+    if cmd := bareArgs(t, calls[0])["command"]; !strings.Contains(cmd.(string), "```python") {
+        t.Fatalf("heredoc payload truncated: %q", cmd)
+    }
+    if fn := calls[1]["function"].(map[string]interface{}); fn["name"] != "web_search" {
+        t.Fatalf("second call = %v, want web_search — the heredoc's ``` wrongly toggled fence state", fn["name"])
+    }
+}
+
+// Mirror image: a real fence around a documentation example must still be
+// caught even when the fenced text itself looks like a call with a quoted
+// argument, so quote-awareness cannot be used to suppress fence detection
+// generally.
+func TestBareCallRealFenceStillCaughtNearQuotedExample(t *testing.T) {
+    in := "```text\nbash(command=\"echo hello\")\n```\n" +
+        "\nweb_search(query=\"hello\")"
+    names := []string{"bash", "web_search"}
+    calls := bareCalls(t, in, names)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 call (web_search only), got %d: %#v", len(calls), calls)
+    }
+    if calls[0]["function"].(map[string]interface{})["name"] != "web_search" {
+        t.Fatalf("fenced bash example fired as a call")
+    }
+}
+
+// ── fence state across a mid-stream rearm (issue #23 interaction) ───────────
+
+// A ``` fence opened before an upstream deep edit_content rewind must still
+// be open after rearmAgentInterceptor rebuilds the interceptor, or a
+// documentation example split across the rewind boundary fires as a real
+// call. This is the scenario that made the bug hard to pin down in the
+// field (a long capture full of edit_content events): the fence check alone
+// is not sufficient without this.
+func TestBareCallFenceStatePreservedAcrossRearm(t *testing.T) {
+    withAgentVariant(t, "modern")
+
+    names := []string{"bash"}
+    live := newAgentInterceptor(names)
+
+    // Open a fence and pad well past the streaming hold-back window so the
+    // fence line itself is safely committed, not sitting in the tail this
+    // Feed call keeps buffered for the next one.
+    content1, calls1 := live.feed(
+        "Here is the syntax:\n```\n" +
+            strings.Repeat("padding so the fence line clears the hold-back window. ", 3) + "\n")
+    if len(calls1) != 0 {
+        t.Fatalf("part 1 produced %d calls before any rewind", len(calls1))
+    }
+
+    // Simulate the upstream deep rewind (issue #23): the caller detects
+    // FullText no longer extends what was already forwarded and swaps in a
+    // fresh interceptor.
+    live = rearmAgentInterceptor(live)
+
+    // The model restates the example after the rewind, still inside the
+    // fence opened in part 1. If bareFenceOpen was lost on rearm, this
+    // reads as a real, complete call and fires — with a destructive
+    // argument, so a false fire here is not a subtle test failure.
+    content2, calls2 := live.feed("bash(command=\"rm -rf /\")\n```\n")
+    if len(calls2) != 0 {
+        t.Fatalf("documentation example fired as a call after rearm: %d calls (content so far: %q)",
+            len(calls2), content1+content2)
+    }
+
+    // Once the fence actually closes and a real, unfenced call follows, it
+    // must still be recognised — the fix must not simply wedge fenceOpen at
+    // true forever.
+    content3, calls3 := live.feed("\nbash(command=\"ls\")")
+    finalContent, finalCalls := live.finish()
+    if len(calls3)+len(finalCalls) != 1 {
+        t.Fatalf("want exactly 1 real call after the fence closed, got %d+%d (content so far: %q)",
+            len(calls3), len(finalCalls), content1+content2+content3+finalContent)
+    }
+}

--- a/internal/zbridge/agent_native.go
+++ b/internal/zbridge/agent_native.go
@@ -529,7 +529,7 @@ func (in *AgentStreamInterceptor) drainNativeBlock(rest string, canonicalStart i
                 return false, false
             }
             if nStart > 0 {
-                *content = append(*content, rest[:nStart])
+                in.commitContent(rest[:nStart], content)
             }
             *toolCalls = append(*toolCalls, ParseAgentToolCalls(rest[nStart:])...)
             in.offset += len(rest)
@@ -539,14 +539,14 @@ func (in *AgentStreamInterceptor) drainNativeBlock(rest string, canonicalStart i
         // Emit what precedes the block and hold the rest until it closes, so
         // half a block never reaches the client as text.
         if nStart > 0 {
-            *content = append(*content, rest[:nStart])
+            in.commitContent(rest[:nStart], content)
             in.offset += nStart
         }
         return true, false
     }
     blockEnd := nStart + endIdx + len(nativeToolClose)
     if nStart > 0 {
-        *content = append(*content, rest[:nStart])
+        in.commitContent(rest[:nStart], content)
     }
     *toolCalls = append(*toolCalls, ParseAgentToolCalls(rest[nStart:blockEnd])...)
     in.offset += blockEnd

--- a/internal/zbridge/anthropic.go
+++ b/internal/zbridge/anthropic.go
@@ -430,14 +430,14 @@ func anthropicMessagesHandler(w http.ResponseWriter, r *http.Request) {
     }
 
     if stream {
-        anthropicStreamResponse(w, prompt, opts, model, requestId)
+        anthropicStreamResponse(w, prompt, opts, model, requestId, agentToolNames(body.Tools))
     } else {
-        anthropicNonStreamResponse(w, prompt, opts, model, requestId)
+        anthropicNonStreamResponse(w, prompt, opts, model, requestId, agentToolNames(body.Tools))
     }
 }
 
 // anthropicStreamResponse converts a ZAIResult stream to Anthropic SSE events.
-func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOptions, model, requestId string) {
+func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOptions, model, requestId string, toolNames []string) {
     w.Header().Set("Content-Type", "text/event-stream")
     w.Header().Set("Cache-Control", "no-cache")
     w.Header().Set("Connection", "keep-alive")
@@ -572,7 +572,7 @@ func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOpti
 
     var interceptor agentInterceptor
     if config.AgentMode {
-        interceptor = newAgentInterceptor()
+        interceptor = newAgentInterceptor(toolNames)
     }
 
     fullContent := ""
@@ -696,7 +696,7 @@ func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOpti
 
         // Safety net: fallback tool call extraction at stream end
         if !toolCallEmitted {
-            toolCalls := agentExtractToolCalls(fullContent)
+            toolCalls := agentExtractToolCalls(fullContent, toolNames...)
             for _, tc := range toolCalls {
                 emitToolCallEvent(tc)
             }
@@ -728,7 +728,7 @@ func anthropicStreamResponse(w http.ResponseWriter, prompt string, opts SendOpti
 }
 
 // anthropicNonStreamResponse produces a single Anthropic message object.
-func anthropicNonStreamResponse(w http.ResponseWriter, prompt string, opts SendOptions, model, requestId string) {
+func anthropicNonStreamResponse(w http.ResponseWriter, prompt string, opts SendOptions, model, requestId string, toolNames []string) {
     ch, err := sendToZAI(prompt, opts)
     if err != nil {
         writeJSON(w, statusFromError(err.Error()), formatAnthropicError("api_error", err.Error()))
@@ -764,9 +764,9 @@ func anthropicNonStreamResponse(w http.ResponseWriter, prompt string, opts SendO
     }
 
     if config.AgentMode {
-        toolCalls := agentExtractToolCalls(fullContent)
+        toolCalls := agentExtractToolCalls(fullContent, toolNames...)
         if len(toolCalls) > 0 {
-            stripped := agentStripToolCalls(fullContent)
+            stripped := agentStripToolCalls(fullContent, toolNames...)
             if stripped != "" {
                 content = append(content, map[string]interface{}{
                     "type": "text",

--- a/internal/zbridge/handlers.go
+++ b/internal/zbridge/handlers.go
@@ -172,7 +172,7 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 
         var interceptor agentInterceptor
         if config.AgentMode {
-            interceptor = newAgentInterceptor()
+            interceptor = newAgentInterceptor(agentToolNames(body.Tools))
         }
         toolCallEmitted := false
 
@@ -300,7 +300,7 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 
                 // Safety net: fallback tool call extraction at stream end
                 if !toolCallEmitted {
-                    fallbackCalls := agentExtractToolCalls(fullContent)
+                    fallbackCalls := agentExtractToolCalls(fullContent, agentToolNames(body.Tools)...)
                     if len(fallbackCalls) > 0 {
                         for _, tc := range fallbackCalls {
                             emitToolCallDelta(tc)
@@ -367,9 +367,9 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 
         // Agent-mode: parse out tool-call blocks for non-stream response
         if config.AgentMode {
-            toolCalls := agentExtractToolCalls(fullContent)
+            toolCalls := agentExtractToolCalls(fullContent, agentToolNames(body.Tools)...)
             if len(toolCalls) > 0 {
-                stripped := agentStripToolCalls(fullContent)
+                stripped := agentStripToolCalls(fullContent, agentToolNames(body.Tools)...)
                 writeJSON(w, 200, map[string]interface{}{
                     "id":      "chatcmpl-" + requestId,
                     "object":  "chat.completion",

--- a/internal/zbridge/sse_toolcall_test.go
+++ b/internal/zbridge/sse_toolcall_test.go
@@ -63,7 +63,7 @@ func sseToolCallStream(t *testing.T, upstreamText string, chunkEvery int) (
     // 3. Replay the exact chatCompletionsHandler stream logic (agent-mode
     //    branch): fullContent accumulation + interceptor feed + tool-call
     //    delta emission.
-    interceptor := newAgentInterceptor()
+    interceptor := newAgentInterceptor(nil)
     fullContent := ""
     sawEndMarker := false
     for _, result := range results {


### PR DESCRIPTION
> **Reopened as a fresh PR.** The original #35 (from fork `ItszFinn:fix/bare-tool-calls`) was auto-closed when the base repository's history was rebased, which severed the fork's ancestry and made the PR unmergeable. Its single commit (`788e5cf`, authored by @ItszFinn) was cherry-picked verbatim onto current `main` — no changes to the content, authorship preserved. This PR replaces that one; the original body follows, with the stale "stacked on #34" note removed since #34 is merged.

---

## Problem

Beyond the `<<<TOOL_CALL>>>` dialects #34 handles, the model sometimes drops every envelope and writes the call as a plain function invocation at the start of a line, most often right after its `<details>` block closes:

```
</details>
bash(i="Inspecting the upstream commit", command="git -C ../repo show --stat --oneline origin/main")
```

Neither the canonical `<<<TOOL_CALL>>>` markers nor Zhipu's native tags are present, so nothing downstream recognises it and the line reaches the client as assistant text, with the usual consequence that the model imitates its own broken output on the next turn.

## Evidence, and its limits

Four captures of this shape, from separate sessions of an agent client. One `LOG_LEVEL=debug` run caught it upstream: a single SSE event ended with

```
…runtime.go + untracked Dockerfile etc.).\n</details>\nbash
```

and the next carried `(i="Inspecting today's upstream commit for overlap with local patches", command="git -C ../a`, with an `edit_content` event completing the command. Because `</details>\nbash` sits inside one event, the missing envelope is not an artefact of how the log was read.

**I cannot give you a rate.** The debug log carries no request id, so concurrent requests interleave and cannot be separated with confidence; my first attempt to count occurrences that way produced a number I had to throw away. That is filed separately as #36. Eight requests captured one at a time all used the canonical markers, so the shape does not appear in short single-turn traffic. The capture that did show it had a 36k-token prompt, which is the difference I would look at first.

## Change

Recognising a bare call is only safe because the request declares its tools. `grep(pattern="x")` in prose is indistinguishable from a call by shape alone, so three conditions all have to hold:

- the name matches a **declared** tool,
- the invocation **starts a line** (leading indentation allowed, since the models indent under list items),
- its **argument list is complete** and parses, as keyword arguments or as a JSON object.

Without a tool list nothing here fires at all, which is also why every existing test is unchanged.

The declared names are threaded from the request into the interceptor and into the finished-text parsers, so the streaming and non-streaming paths of both handlers see them. The streaming hold-back window grows to cover the longest declared name plus its bracket, otherwise a name split across upstream chunks is flushed as content before its arguments arrive.

An argument list that never closes stays text rather than becoming a command the model never finished writing, and an explicit envelope always wins when one starts at or before the same point.

## Tests

- the captured call, through the parser and the stripper
- prose mentioning a declared tool mid-sentence, in backticks, and at the end of a sentence; none may be touched
- undeclared names and an empty tool list: inert
- four truncated forms that must stay text
- nested brackets and quotes inside a command (`awk '{print $1}' | grep -E '(a|b)'`)
- the streaming path at six chunk sizes, plus a truncated stream that must surface rather than vanish
- an end-to-end run through `streamSSEResponse` where the name, the bracket and the argument list arrive in three separate SSE events, the last an `edit_content` completion

Existing suite green, `go vet` clean.

## Verification

The build ran against live `chat.z.ai` (glm-5.3): twelve streaming tool-call requests, all clean, no regression in the canonical path. The bare shape did not occur during those runs, so the recognition itself is proven by the tests rather than by a live catch. I would rather say that than imply a reproduction I do not have.

---

## Maintainer review note (carried over from the original PR discussion)

This PR carries a **changes-requested** review from before the rebase, with one blocking finding:

**Unfenced code examples at line start are false positives.** Both of these get transformed into live tool calls today:

```
The request looks like:
web_search{"query":"hello","limit":5}
That is the whole request.
```

```
You can also call it like:
web_search(query="test", limit=1)
in your own code.
```

i.e. a model *teaching the client how to call the tool* — an unfenced JSON example or invocation-shaped line, both naturally at line start, both satisfying name-matches-declared + line-start + complete-args — is silently converted into an execution. The captured dialects in #34 can't have this problem because their envelopes are explicit; the bare form has no such disambiguator, which is exactly why it's riskier.

Suggested guard: skip a candidate when it sits inside a fenced code block (scan the text before `call.start` for an unclosed ` ``` ` line). If fence-tracking is too fragile for streaming, an alternative is requiring the previous non-empty line to not be sentence-like, though that's a weaker heuristic.

Everything else (gates, threading, hold-back window, tests) was verified merge-ready on the original branch: build/vet clean, full suite green, sequential calls, CRLF, empty/nil edges, nested brackets in values, surrounding-text preservation, positional-arg forms staying text, and fenced examples staying text.
