### PR TITLE
fix(agent): fence-blind bare-call detection (PR #38).

### DIFF
--- a/internal/zbridge/agent.go
+++ b/internal/zbridge/agent.go
@@ -988,6 +988,22 @@ type AgentStreamInterceptor struct {
     toolNames []string
     bareKeep  int // hold-back floor covering the longest name plus its bracket
 
+    // bareFenceOpen tracks, for the bare-call recognizer only, whether the
+    // model's output is currently inside an open ``` markdown fence: a
+    // declared-tool invocation that is merely a documentation example inside
+    // a fence must not be mistaken for a real call (see agent_bare.go).
+    //
+    // This is state about the stream as a whole, not a value re-derived from
+    // whatever is left in the buffer: a fence opened in text already
+    // committed to the client (or consumed as part of an earlier bare call)
+    // is invisible to any scan that only looks at what has not yet been
+    // sent, so it must be threaded forward explicitly. It is updated in
+    // exactly two places — commitContent, for ordinary text, and the
+    // successful branch of drainBareCall, for a recognised call's own span —
+    // and must be carried across rearmAgentInterceptor (see there) or a
+    // mid-stream rewind silently forgets it.
+    bareFenceOpen bool
+
     // ── incremental tool-call streaming state ──
     inCall         bool   // between the opening and closing markers
     tcBlockStart   int    // offset of the opening marker (for leak-as-content)
@@ -1259,7 +1275,7 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
             if final {
                 // End of data: everything left is ordinary content.
                 if rest != "" {
-                    content = append(content, rest)
+                    in.commitContent(rest, &content)
                     in.offset = len(in.buffer)
                 }
                 break
@@ -1281,7 +1297,7 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
                     cut--
                 }
                 if cut > 0 {
-                    content = append(content, rest[:cut])
+                    in.commitContent(rest[:cut], &content)
                     in.offset += cut
                 }
             }
@@ -1290,7 +1306,7 @@ func (in *AgentStreamInterceptor) drain(final bool) AgentParsedChunk {
         if start > 0 {
             piece := TrimTrailingAgentFence(rest[:start])
             if piece != "" {
-                content = append(content, piece)
+                in.commitContent(piece, &content)
             }
             in.offset += start
         }
@@ -1368,7 +1384,7 @@ func (in *AgentStreamInterceptor) drainToolCall(final bool, content *[]string, t
                 in.callIndex++
             } else {
                 // invalid model block: leave it as visible text
-                *content = append(*content, in.buffer[in.tcBlockStart:end+markerLen])
+                in.commitContent(in.buffer[in.tcBlockStart:end+markerLen], content)
             }
             in.offset = end + markerLen
             in.finishCall()
@@ -1674,16 +1690,27 @@ func (in *AgentStreamInterceptor) setToolNames(names []string) {
 // while preserving the client-visible call-index sequence: a call streamed
 // before the rewind keeps its index, and the re-emitted block takes the
 // next one instead of colliding inside SDK accumulation.
+//
+// It also preserves bareFenceOpen. Without this, a rewind landing while the
+// model's output is mid-way through a ``` fence resets the fresh
+// interceptor to "not in a fence", and a bare-call example inside that same
+// fence — the exact false positive the fence check exists to catch — is
+// misread as a real call again, only now intermittently and after the
+// stream has already been rewound once, which is harder to reproduce than
+// the original report.
 func rearmAgentInterceptor(old agentInterceptor) agentInterceptor {
     var names []string
+    var fenceOpen bool
     if o, ok := old.(*modernAgentInterceptor); ok {
         names = o.in.toolNames
+        fenceOpen = o.in.bareFenceOpen
     }
     fresh := newAgentInterceptor(names)
     switch o := old.(type) {
     case *modernAgentInterceptor:
         if f, ok := fresh.(*modernAgentInterceptor); ok {
             f.in.callIndex = o.in.callIndex
+            f.in.bareFenceOpen = fenceOpen
         }
     case *legacyAgentInterceptor:
         if f, ok := fresh.(*legacyAgentInterceptor); ok {

--- a/internal/zbridge/agent_bare.go
+++ b/internal/zbridge/agent_bare.go
@@ -81,61 +81,177 @@ func atLineStart(s string, i int, prevByte byte) bool {
     return prevByte == 0 || prevByte == '\n' || prevByte == '\r'
 }
 
-// findBareCall returns the first envelope-less invocation of a declared tool
-// in s. complete is false when an invocation starts but its argument list has
-// not closed yet. The caller must then hold the text back rather than emit
-// it, because the rest of the call is still arriving.
-func findBareCall(s string, names []string, prevByte byte) (call bareCall, found, complete bool) {
-    if len(names) == 0 {
-        return bareCall{}, false, false
+// fenceDelimLine reports whether line is a markdown code-fence delimiter:
+// optional leading horizontal whitespace followed by at least three
+// backticks. Both the opening line (which may carry a language tag after the
+// backticks, e.g. "```go") and the closing line (bare backticks) match — a
+// fence toggles either way.
+//
+// This deliberately does not implement the rest of CommonMark's fence rules
+// (matching backtick/tilde counts, ~~~ fences, 4-space indented code blocks).
+// Every model capture examined for this fix used plain ``` fences; extending
+// coverage to those forms is a separate, larger change and is out of scope
+// here — see the PR description for the reasoning.
+func fenceDelimLine(line string) bool {
+    return strings.HasPrefix(strings.TrimLeft(line, " \t"), "```")
+}
+
+// advanceFenceState folds free text s into the running markdown-fence state,
+// toggling once per fence-delimiter line (see fenceDelimLine). open is the
+// state entering s; the return value is the state after it.
+//
+// Callers must use this — never re-derive fence state from a suffix window
+// of the stream — because a fence opened in text already committed to the
+// client is invisible to any later scan that only looks at what has not yet
+// been sent.
+func advanceFenceState(s string, open bool) bool {
+    for len(s) > 0 {
+        nl := strings.IndexByte(s, '\n')
+        var line string
+        if nl < 0 {
+            line, s = s, ""
+        } else {
+            line, s = s[:nl], s[nl+1:]
+        }
+        if fenceDelimLine(line) {
+            open = !open
+        }
     }
-    best := -1
-    var bestName string
-    for _, name := range names {
-        for pos := 0; ; {
-            idx := strings.Index(s[pos:], name)
-            if idx < 0 {
-                break
+    return open
+}
+
+// advanceFenceStateOverCall folds one complete bare-call span (name through
+// its closing bracket, as returned by findBareCall) into the running fence
+// state. It mirrors bareArgsEnd's own quote/escape tracking so the two can
+// never disagree about where a quoted argument value starts or ends: a ```
+// sequence inside a quoted value is argument data, not a markdown fence, and
+// must not toggle the state — see the PR description for a live example
+// (a heredoc-style shell command whose payload contains a fenced code
+// block). Only backticks in the unquoted parts of the call (which is
+// realistically just the name and the bracket/comma/key structure) can ever
+// toggle it.
+func advanceFenceStateOverCall(call string, open bool) bool {
+    var quote byte
+    lineStart := 0
+    for i := 0; i < len(call); i++ {
+        c := call[i]
+        if quote != 0 {
+            switch c {
+            case '\\':
+                i++
+            case quote:
+                quote = 0
             }
-            at := pos + idx
-            pos = at + 1
-            after := at + len(name)
-            if after >= len(s) {
-                // The name ends the text; its delimiter has not arrived.
-                if atLineStart(s, at, prevByte) && (best < 0 || at < best) {
+            continue
+        }
+        switch c {
+        case '"', '\'':
+            quote = c
+        case '\n':
+            if fenceDelimLine(call[lineStart:i]) {
+                open = !open
+            }
+            lineStart = i + 1
+        }
+    }
+    if fenceDelimLine(call[lineStart:]) {
+        open = !open
+    }
+    return open
+}
+
+// findBareCall returns the first envelope-less invocation of a declared tool
+// in s that is not sitting inside an open ``` fence — a fenced occurrence is
+// a documentation example, not a call, so it is skipped and the search
+// continues past it (a real call may still follow once the fence closes).
+//
+// fenceOpen is the fence state immediately before s. fenceAfter is that same
+// state immediately after the returned call, or after all of s when no call
+// is found or the trailing one is still incomplete; callers MUST carry it
+// forward as the next call's fenceOpen rather than recomputing it from a
+// shorter window (see advanceFenceState's doc comment for why).
+//
+// complete is false when an invocation starts but its argument list has not
+// closed yet. The caller must then hold the text back rather than emit it,
+// because the rest of the call is still arriving.
+func findBareCall(s string, names []string, prevByte byte, fenceOpen bool) (call bareCall, found, complete bool, fenceAfter bool) {
+    if len(names) == 0 {
+        return bareCall{}, false, false, fenceOpen
+    }
+    scanned := 0 // s[:scanned] has already been folded into state
+    searchFrom := 0
+    state := fenceOpen
+    for {
+        best := -1
+        var bestName string
+        for _, name := range names {
+            for pos := searchFrom; ; {
+                idx := strings.Index(s[pos:], name)
+                if idx < 0 {
+                    break
+                }
+                at := pos + idx
+                pos = at + 1
+                after := at + len(name)
+                if after >= len(s) {
+                    // The name ends the text; its delimiter has not arrived.
+                    if atLineStart(s, at, prevByte) && (best < 0 || at < best) {
+                        best, bestName = at, name
+                    }
+                    break
+                }
+                if s[after] != '(' && s[after] != '{' {
+                    continue
+                }
+                if !atLineStart(s, at, prevByte) {
+                    continue
+                }
+                if best < 0 || at < best {
                     best, bestName = at, name
                 }
                 break
             }
-            if s[after] != '(' && s[after] != '{' {
-                continue
-            }
-            if !atLineStart(s, at, prevByte) {
-                continue
-            }
-            if best < 0 || at < best {
-                best, bestName = at, name
-            }
-            break
         }
+        if best < 0 {
+            return bareCall{}, false, false, advanceFenceState(s[scanned:], state)
+        }
+
+        // Fold the free text between the previous scan point and this
+        // candidate before judging it, then advance the scan point so the
+        // same bytes are never folded twice across loop iterations.
+        state = advanceFenceState(s[scanned:best], state)
+        scanned = best
+
+        if state {
+            // Inside an open fence: a documentation example, not a call.
+            // Skip past this occurrence and keep looking.
+            searchFrom = best + len(bestName)
+            continue
+        }
+
+        open := best + len(bestName)
+        if open >= len(s) {
+            return bareCall{start: best, name: bestName}, true, false, state
+        }
+        end, closed := bareArgsEnd(s, open)
+        if !closed {
+            return bareCall{start: best, name: bestName}, true, false, state
+        }
+        args, ok := parseBareArgs(s[open:end])
+        if !ok {
+            // Complete but unreadable: not a call we can build, leave it as
+            // text (matches the pre-fence-awareness behaviour of giving up
+            // on this scan entirely rather than guessing past a malformed
+            // call).
+            return bareCall{}, false, false, state
+        }
+        // The call span itself is never emitted as content — it becomes a
+        // tool_call — but it still occupies space in the model's output, so
+        // backticks inside it (outside any quoted value) still affect what
+        // a later scan on this stream sees.
+        fenceAfter = advanceFenceStateOverCall(s[best:end], state)
+        return bareCall{start: best, end: end, name: bestName, args: args}, true, true, fenceAfter
     }
-    if best < 0 {
-        return bareCall{}, false, false
-    }
-    open := best + len(bestName)
-    if open >= len(s) {
-        return bareCall{start: best, name: bestName}, true, false
-    }
-    end, closed := bareArgsEnd(s, open)
-    if !closed {
-        return bareCall{start: best, name: bestName}, true, false
-    }
-    args, ok := parseBareArgs(s[open:end])
-    if !ok {
-        // Complete but unreadable: not a call we can build, leave it as text.
-        return bareCall{}, false, false
-    }
-    return bareCall{start: best, end: end, name: bestName, args: args}, true, true
 }
 
 // bareArgsEnd finds the index just past the argument list that opens at
@@ -203,9 +319,10 @@ func TranslateBareToolCalls(text string, names []string) string {
     var b strings.Builder
     rest := text
     var prev byte
+    fenceOpen := false
     changed := false
     for {
-        call, found, complete := findBareCall(rest, names, prev)
+        call, found, complete, fenceAfter := findBareCall(rest, names, prev, fenceOpen)
         if !found || !complete {
             b.WriteString(rest)
             break
@@ -218,6 +335,7 @@ func TranslateBareToolCalls(text string, names []string) string {
         b.WriteString(rest[:call.start])
         b.WriteString(agentToolStart + string(encoded) + agentToolEnd)
         changed = true
+        fenceOpen = fenceAfter
         if call.end > 0 {
             prev = rest[call.end-1]
         }
@@ -227,6 +345,23 @@ func TranslateBareToolCalls(text string, names []string) string {
         return text
     }
     return b.String()
+}
+
+// commitContent appends s to content and folds it into the interceptor's
+// running bare-call fence state (in.bareFenceOpen — see its doc comment on
+// AgentStreamInterceptor). This is the ONLY place that state may change for
+// ordinary text: every append to *content anywhere in this package's drain
+// path must go through here rather than appending directly, or the fence
+// state silently desyncs from what the client actually receives and the
+// false-positive this file exists to prevent can resurface. s is assumed to
+// be free text, not the span of a recognised call — see
+// advanceFenceStateOverCall for that case.
+func (in *AgentStreamInterceptor) commitContent(s string, content *[]string) {
+    if s == "" {
+        return
+    }
+    *content = append(*content, s)
+    in.bareFenceOpen = advanceFenceState(s, in.bareFenceOpen)
 }
 
 // drainBareCall handles an envelope-less invocation met while streaming. It
@@ -245,12 +380,18 @@ func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nat
     if in.offset > 0 {
         prev = in.buffer[in.offset-1]
     }
-    call, found, complete := findBareCall(rest, in.toolNames, prev)
+    call, found, complete, fenceAfter := findBareCall(rest, in.toolNames, prev, in.bareFenceOpen)
     if !found {
+        // All of rest was free text as far as bare-call scanning goes, but
+        // it may not all be committed this pass (the general hold-back path
+        // further down in drain() may keep a tail). Do not fold it here —
+        // whatever actually gets committed will be folded through
+        // commitContent at the point it is committed.
         return false, false
     }
     // Either envelope wins when it starts at or before this point: both are
-    // explicit, and the canonical one streams properly.
+    // explicit, and the canonical one streams properly. Leave in.bareFenceOpen
+    // untouched — the winning path commits its own preceding text.
     if canonicalStart >= 0 && canonicalStart <= call.start {
         return false, false
     }
@@ -264,7 +405,7 @@ func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nat
             return false, false
         }
         if call.start > 0 {
-            *content = append(*content, rest[:call.start])
+            in.commitContent(rest[:call.start], content)
             in.offset += call.start
         }
         return true, false
@@ -274,9 +415,13 @@ func (in *AgentStreamInterceptor) drainBareCall(rest string, canonicalStart, nat
         return false, false
     }
     if call.start > 0 {
-        *content = append(*content, rest[:call.start])
+        in.commitContent(rest[:call.start], content)
     }
     *toolCalls = append(*toolCalls, ParseAgentToolCalls(agentToolStart+string(encoded)+agentToolEnd)...)
+    // fenceAfter already accounts for both the leading text just committed
+    // above and the call span itself (see findBareCall) — this replaces,
+    // rather than adds to, whatever commitContent just set.
+    in.bareFenceOpen = fenceAfter
     in.offset += call.end
     in.pendingSep = true
     return true, true

--- a/internal/zbridge/agent_bare_test.go
+++ b/internal/zbridge/agent_bare_test.go
@@ -284,3 +284,133 @@ func TestBareCallThroughSSEPipeline(t *testing.T) {
 }
 
 func itoa(n int) string { return strconv.Itoa(n) }
+
+// ── fence-awareness (security boundary: doc examples must not fire) ─────────
+
+// A declared-tool invocation written purely as a documentation example
+// inside a fenced code block must stay text, in both argument forms. Without
+// fence-awareness, atLineStart + a declared name + complete arguments is
+// indistinguishable from a real call, so a model explaining its own tool
+// syntax could trigger a real invocation.
+func TestBareCallInsideFencedDocExample(t *testing.T) {
+    cases := []string{
+        "Example:\n```text\nweb_search{\"query\":\"hello\"}\n```\n",
+        "Example:\n```text\nweb_search(query=\"test\", limit=1)\n```\n",
+    }
+    names := []string{"web_search"}
+    for _, in := range cases {
+        if calls := bareCalls(t, in, names); len(calls) != 0 {
+            t.Fatalf("fenced example fired as a call: %q -> %d calls", in, len(calls))
+        }
+        if got := TranslateBareToolCalls(in, names); got != in {
+            t.Fatalf("fenced example rewritten: %q -> %q", in, got)
+        }
+    }
+}
+
+// A fenced example must not blind the parser to a real call in the same
+// message once the fence closes — skip the fenced candidate, keep scanning.
+func TestBareCallSkipsFencedThenFindsReal(t *testing.T) {
+    in := "Example:\n```text\nweb_search(query=\"documentation\")\n```\n" +
+        "\nweb_search(query=\"real\")"
+    names := []string{"web_search"}
+    calls := bareCalls(t, in, names)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 call (the one after the fence), got %d", len(calls))
+    }
+    if args := bareArgs(t, calls[0]); args["query"] != "real" {
+        t.Fatalf("wrong call fired: %#v", args)
+    }
+}
+
+// ── quoted-argument isolation (``` inside call data is not a fence) ─────────
+
+// A ``` sequence that is argument data — e.g. a heredoc payload for a real
+// shell call — must not be mistaken for a markdown fence. If it were, it
+// would flip in.bareFenceOpen and could make the genuinely real call right
+// after it register as "inside a fence" and get skipped.
+func TestBareCallBacktickInQuotedArgDoesNotToggleFence(t *testing.T) {
+    in := "bash(command=\"cat <<'EOF'\n```python\nprint('hi')\n```\nEOF\")\n" +
+        "\nweb_search(query=\"hello\")"
+    names := []string{"bash", "web_search"}
+    calls := bareCalls(t, in, names)
+    if len(calls) != 2 {
+        t.Fatalf("want 2 calls (bash and web_search), got %d: %#v", len(calls), calls)
+    }
+    if fn := calls[0]["function"].(map[string]interface{}); fn["name"] != "bash" {
+        t.Fatalf("first call = %v, want bash", fn["name"])
+    }
+    if cmd := bareArgs(t, calls[0])["command"]; !strings.Contains(cmd.(string), "```python") {
+        t.Fatalf("heredoc payload truncated: %q", cmd)
+    }
+    if fn := calls[1]["function"].(map[string]interface{}); fn["name"] != "web_search" {
+        t.Fatalf("second call = %v, want web_search — the heredoc's ``` wrongly toggled fence state", fn["name"])
+    }
+}
+
+// Mirror image: a real fence around a documentation example must still be
+// caught even when the fenced text itself looks like a call with a quoted
+// argument, so quote-awareness cannot be used to suppress fence detection
+// generally.
+func TestBareCallRealFenceStillCaughtNearQuotedExample(t *testing.T) {
+    in := "```text\nbash(command=\"echo hello\")\n```\n" +
+        "\nweb_search(query=\"hello\")"
+    names := []string{"bash", "web_search"}
+    calls := bareCalls(t, in, names)
+    if len(calls) != 1 {
+        t.Fatalf("want 1 call (web_search only), got %d: %#v", len(calls), calls)
+    }
+    if calls[0]["function"].(map[string]interface{})["name"] != "web_search" {
+        t.Fatalf("fenced bash example fired as a call")
+    }
+}
+
+// ── fence state across a mid-stream rearm (issue #23 interaction) ───────────
+
+// A ``` fence opened before an upstream deep edit_content rewind must still
+// be open after rearmAgentInterceptor rebuilds the interceptor, or a
+// documentation example split across the rewind boundary fires as a real
+// call. This is the scenario that made the bug hard to pin down in the
+// field (a long capture full of edit_content events): the fence check alone
+// is not sufficient without this.
+func TestBareCallFenceStatePreservedAcrossRearm(t *testing.T) {
+    withAgentVariant(t, "modern")
+
+    names := []string{"bash"}
+    live := newAgentInterceptor(names)
+
+    // Open a fence and pad well past the streaming hold-back window so the
+    // fence line itself is safely committed, not sitting in the tail this
+    // Feed call keeps buffered for the next one.
+    content1, calls1 := live.feed(
+        "Here is the syntax:\n```\n" +
+            strings.Repeat("padding so the fence line clears the hold-back window. ", 3) + "\n")
+    if len(calls1) != 0 {
+        t.Fatalf("part 1 produced %d calls before any rewind", len(calls1))
+    }
+
+    // Simulate the upstream deep rewind (issue #23): the caller detects
+    // FullText no longer extends what was already forwarded and swaps in a
+    // fresh interceptor.
+    live = rearmAgentInterceptor(live)
+
+    // The model restates the example after the rewind, still inside the
+    // fence opened in part 1. If bareFenceOpen was lost on rearm, this
+    // reads as a real, complete call and fires — with a destructive
+    // argument, so a false fire here is not a subtle test failure.
+    content2, calls2 := live.feed("bash(command=\"rm -rf /\")\n```\n")
+    if len(calls2) != 0 {
+        t.Fatalf("documentation example fired as a call after rearm: %d calls (content so far: %q)",
+            len(calls2), content1+content2)
+    }
+
+    // Once the fence actually closes and a real, unfenced call follows, it
+    // must still be recognised — the fix must not simply wedge fenceOpen at
+    // true forever.
+    content3, calls3 := live.feed("\nbash(command=\"ls\")")
+    finalContent, finalCalls := live.finish()
+    if len(calls3)+len(finalCalls) != 1 {
+        t.Fatalf("want exactly 1 real call after the fence closed, got %d+%d (content so far: %q)",
+            len(calls3), len(finalCalls), content1+content2+content3+finalContent)
+    }
+}

--- a/internal/zbridge/agent_native.go
+++ b/internal/zbridge/agent_native.go
@@ -529,7 +529,7 @@ func (in *AgentStreamInterceptor) drainNativeBlock(rest string, canonicalStart i
                 return false, false
             }
             if nStart > 0 {
-                *content = append(*content, rest[:nStart])
+                in.commitContent(rest[:nStart], content)
             }
             *toolCalls = append(*toolCalls, ParseAgentToolCalls(rest[nStart:])...)
             in.offset += len(rest)
@@ -539,14 +539,14 @@ func (in *AgentStreamInterceptor) drainNativeBlock(rest string, canonicalStart i
         // Emit what precedes the block and hold the rest until it closes, so
         // half a block never reaches the client as text.
         if nStart > 0 {
-            *content = append(*content, rest[:nStart])
+            in.commitContent(rest[:nStart], content)
             in.offset += nStart
         }
         return true, false
     }
     blockEnd := nStart + endIdx + len(nativeToolClose)
     if nStart > 0 {
-        *content = append(*content, rest[:nStart])
+        in.commitContent(rest[:nStart], content)
     }
     *toolCalls = append(*toolCalls, ParseAgentToolCalls(rest[nStart:blockEnd])...)
     in.offset += blockEnd


### PR DESCRIPTION
# Fix: fence-blind bare-call detection (PR #38)

## The bug

`findBareCall` fires whenever a declared tool name sits at the start of a
line with a complete, parseable argument list. It never checks whether that
line is inside a fenced (` ``` `) code block. A model explaining its own tool
syntax in a documentation example satisfies all three conditions — declared
name, line start, complete args — and gets executed for real:

````
web_search{"query":"hello"}
````
or
````
web_search(query="test", limit=1)
````

For a tool with side effects (`bash`, `write_file`, …) this turns harmless
explanatory text into an unintended real invocation.

## Why "just scan backward for an open fence" isn't the whole fix

Fence state has to be **state about the stream as a whole**, not something
recomputed from whatever text is still in the local buffer/window. Two
things break a purely local check:

1. **Streaming.** By the time a candidate is scanned, the fence-opening
   `` ``` `` line may already have been flushed to the client and dropped
   from the window being scanned.
2. **`rearmAgentInterceptor`.** An upstream deep `edit_content` rewind
   (issue #23) discards the interceptor and builds a fresh one. If fence
   state isn't threaded through that swap, a rewind landing mid-fence
   forgets the fence entirely — the exact false positive this fix targets,
   now intermittent and appearing only after a rewind, which is harder to
   reproduce than the original report. Given the original report came from
   a 36k-token capture full of `edit_content` events, this path is not an
   edge case for this bug — it's close to the typical case.

## The invariant

> `bareFenceOpen` tracks the markdown-fence state of the model's output up
> to the current scan point. It changes in exactly two places: when free
> text is committed to the client (`commitContent`), and when a recognised
> bare call's own span is consumed (the successful branch of
> `findBareCall`/`drainBareCall`). A `` ``` `` sequence inside a quoted
> argument value is call data, not markdown, and never toggles it.

## What changed, and why each piece is necessary

### `agent_bare.go`

- **`fenceDelimLine` / `advanceFenceState`** — the fence-toggle primitive.
  Deliberately narrow: leading-whitespace + `` ``` ``, nothing more. See
  "Out of scope" below for why `~~~` and indented blocks aren't covered.
- **`advanceFenceStateOverCall`** — folds a *recognised call's own span*
  into the fence state, but mirrors `bareArgsEnd`'s quote/escape tracking so
  a `` ``` `` inside a quoted argument (e.g. a heredoc payload) is never
  mistaken for a fence delimiter. This matters because `bareArgsEnd`
  already accepts newlines inside quoted values (tested by
  `TestBareCallNestedBrackets`), so a multi-line quoted argument containing
  a code fence is grammar the parser already claims to support — it has to
  be handled correctly, not just excluded.
- **`findBareCall`** — now takes `fenceOpen bool` in and returns
  `fenceAfter bool`, in addition to its previous return values. A candidate
  found while `fenceOpen` is true is skipped (not treated as end-of-search)
  and the scan continues past it, because a real call may still follow
  once the fence closes. Every byte of the scanned text is folded into the
  fence state exactly once, in scan order, so re-entrant candidates can't
  double-toggle it.
- **`commitContent`** — the single point where text is appended to
  `*content` and folded into `in.bareFenceOpen`. Every place in this
  package that used to write `*content = append(*content, x)` directly now
  goes through this. The point of centralising it: a future new
  content-flush path only has to remember to call `commitContent`, not to
  independently reason about fence state.
- **`TranslateBareToolCalls` / `drainBareCall`** — thread `fenceOpen` /
  `fenceAfter` through the loop instead of recomputing it per call.

### `agent.go`

- **`AgentStreamInterceptor.bareFenceOpen`** — the persistent field itself,
  documented with the invariant above.
- **Three `content = append(content, …)` sites in `drain()`, one in
  `drainToolCall`'s "invalid model block → visible text" fallback** — routed
  through `commitContent`.
- **`rearmAgentInterceptor`** — carries `bareFenceOpen` from the old
  `*modernAgentInterceptor` to the new one, alongside the `callIndex` it
  already carried. This is the fix for the rearm gap described above; without
  it, the rest of the change still has the hole it's meant to close.

### `agent_native.go`

- Three `*content = append(*content, rest[:nStart])` sites in
  `drainNativeBlock`, routed through `commitContent`. (The native
  `<tool_call>...</tool_call>` block's own payload is JSON, and — like a
  bare call's quoted arguments — is excluded from fence-toggling by
  construction: it's never passed to `advanceFenceState` at all, only the
  free text preceding it is.)

## Tests added (`agent_bare_test.go`)

| Test | Proves |
|---|---|
| `TestBareCallInsideFencedDocExample` | Both argument forms of the reviewer's original report stay text. |
| `TestBareCallSkipsFencedThenFindsReal` | A fenced example doesn't blind the scan to a real call later in the same message. |
| `TestBareCallBacktickInQuotedArgDoesNotToggleFence` | A heredoc-style real call whose payload contains a code fence doesn't corrupt fence parity for the call right after it. |
| `TestBareCallRealFenceStillCaughtNearQuotedExample` | The quote-awareness added for the above can't be (ab)used to suppress fence detection generally. |
| `TestBareCallFenceStatePreservedAcrossRearm` | **The blocking one.** Opens a fence, forces a `rearmAgentInterceptor` swap mid-fence, and confirms a documentation example split across that boundary still stays text — with a destructive `rm -rf /` argument, so a false fire here isn't a subtle assertion failure. |

All pre-existing tests in the package continue to pass unmodified
(`go test ./internal/zbridge/...`, full suite green).

## Out of scope (intentionally)

`~~~` fences and 4-space-indented code blocks are not recognised.

This is a difference in kind from the quoted-argument case above, not just a
lower priority:

- `fenceDelimLine` never claimed to support them — leaving them out doesn't
  regress *any* existing contract, whereas the quoted-argument case broke a
  form (`bareArgsEnd`'s multi-line quoted string) the parser already
  supported.
- Every capture examined for this bug uses plain `` ``` `` fences; there's
  no observed evidence of either form from this model family.
- Supporting them correctly means matching opening/closing delimiter
  lengths and CommonMark's indentation rules (including interaction with
  surrounding list/blockquote indentation) — a materially larger, separate
  change, not a small addition to this fix.

Worth stating explicitly in the PR description so it reads as a deliberate
boundary rather than an oversight.