### PR TITLE
fix(search): correct webSearch flag, add Advanced Search, agent-mode gate (issue #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Anthropic clients authenticate via `x-api-key` (same value as `AUTH_TOKEN`); `an
 | `thinking` | object | *(per-model)* | `{"type":"enabled"}` / `{"type":"disabled"}` → `enable_thinking` |
 | `reasoning_effort` | string | *(empty)* | `"high"`/`"max"` — forwarded only if the model supports it; forces `enable_thinking=true` |
 | `tools` | array | *(empty)* | OpenAI-style tools (requires agent mode) |
-| `webSearch` / `search` | bool | *(per-model)* | Toggle `auto_web_search` + `web_search` |
+| `webSearch` / `search` | bool | *(per-model)* | Toggle the WebSearch feature (sets `auto_web_search` in the upstream `features` payload) |
+| `advancedSearch` | bool | `false` | **Advanced Search** (chat.z.ai's MCP variant of web search) — adds `"mcp_servers":["advanced-search"]` to the upstream completions payload; implies `webSearch=true` |
 
 #### Image input (vision)
 
@@ -350,6 +351,35 @@ Enabling agent mode also starts the background captcha cache (2 pre-generated pa
 
 ---
 
+## Web Search & Advanced Search (issue #42)
+
+Two separate things live behind the globe icon on chat.z.ai, and the bridge now maps both onto request flags:
+
+**WebSearch** (`webSearch: true`, or the `search` alias) — the model's built-in search mode. Internally this sets **`auto_web_search: true`** in the upstream `features` payload. That is the only key that actually toggles the feature: the sibling `web_search` key is **always `false` upstream** — sending `true` there does nothing (the server just mirrors it back), which is why a request that "looked" enabled could silently do nothing. The bridge now always pins `features.web_search = false` and never sends `true` for it, no matter what stored overrides say.
+
+**Advanced Search** (`advancedSearch: true`) — not a feature flag at all, but an **MCP server**. On the real chat.z.ai web, toggling Advanced Search makes the frontend add a new top-level field to the completions request payload:
+
+```json
+{
+  "model": "glm-5.3",
+  "chat_id": "...",
+  "messages": [...],
+  "captcha_verify_param": "...",
+  "mcp_servers": ["advanced-search"],
+  "features": { "auto_web_search": true, ... }
+}
+```
+
+`mcp_servers` sits on the same payload level as `captcha_verify_param` (it is *not* inside `features`). When it's present, Z.AI runs the model's searches through the advanced-search MCP tools — the internal `tool_call` events (`retrieve`, `open_url`, …) you see fly by in the SSE stream are that loop at work; they're answered server-side by Z.AI itself and have nothing to do with agent-mode tool calling.
+
+The bridge reproduces this exactly: `advancedSearch: true` adds `"mcp_servers": ["advanced-search"]` to the upstream payload and auto-enables the base web-search toggle (same coupling as the web UI, where Advanced Search hides behind the globe). Citations come back inline as `【turn0search0】` markers in the message text plus `[ref_id=...]` blocks the model quotes from — the `metadata.browser.search_result` on the internal tool responses carries the full source list (title, url, snippet, favicon) for anyone who wants to build a references panel.
+
+**Agent-mode gate** — when agent mode is on, both search toggles are **force-disabled server-side**, even if the request asks for them. Z.AI serves WebSearch through its own internal tool-call loop; mixing that with the agent shim's tool contract makes the model emit internal markers (`retrieve`, `open_url`) as if they were the caller's tools, or refuse to search at all. The request still succeeds — it just runs without server-side search. If you need both, run tool-calling requests without the search flags and let the client's own tools fetch pages.
+
+Both flags are also accepted on the Anthropic `/v1/messages` endpoint (`webSearch`, `search`, `advancedSearch` in the body) and map to the same upstream payload.
+
+---
+
 ## Examples
 
 > Self-hosted examples use `glm-4.7` so they work **without** `ZAI_TOKEN`. For the hosted instance use base URL `https://glm.cognix.sryze.cc/v1`, model `glm-5.2` or `glm-5.3-flash`, same auth.
@@ -455,12 +485,15 @@ zai-api/
 │   ├── agent_test.go              # Whitebox: modern agent shim
 │   ├── db_test.go                 # Whitebox: DB holder, count TTL, graceful swap
 │   ├── sse_garble_test.go         # Whitebox: SSE parser (issue #23)
+│   ├── websearch_test.go          # Whitebox: search payload shapes + agent gate (issue #42)
 │   └── vision_test.go             # Whitebox: url->file-id rewrite
 ├── cmd/token-collector/           # Standalone binary: seeds tokens.sqlite (TUI)
 ├── tests/                         # Blackbox tests (package tests)
 │   ├── session_pool_test.go       # Pool mechanics, chat-delete client, GC wiring
 │   ├── integration_test.go        # E2E HTTP garble regression (issue #23)
+│   ├── toolcall_stream_test.go    # E2E streamed tool calls (agent mode)
 │   ├── db_hotswap_test.go         # E2E /health tokenCount + /sqlite hot-swap
+│   ├── websearch_e2e_test.go      # E2E search flags -> upstream payload (issue #42)
 │   └── vision_test.go             # Vision e2e (upload + files), /v1/models, limits
 └── README.md
 ```

--- a/internal/zbridge/anthropic.go
+++ b/internal/zbridge/anthropic.go
@@ -300,6 +300,19 @@ func anthropicToOpenAIRequest(bodyBytes []byte) ([]byte, error) {
         }
     }
 
+    // Convert the web-search toggles (non-standard Anthropic extensions
+    // this bridge accepts): webSearch/search -> webSearch, advancedSearch
+    // -> advancedSearch. The sendToZAI pipeline treats them the same as
+    // the OpenAI endpoint's flags (issue #42).
+    if ws, ok := req["webSearch"].(bool); ok {
+        out["webSearch"] = ws
+    } else if s, ok := req["search"].(bool); ok {
+        out["webSearch"] = s
+    }
+    if as, ok := req["advancedSearch"].(bool); ok {
+        out["advancedSearch"] = as
+    }
+
     return json.Marshal(out)
 }
 
@@ -342,6 +355,8 @@ func anthropicMessagesHandler(w http.ResponseWriter, r *http.Request) {
         Stream          *bool           `json:"stream"`
         Reasoning       *bool           `json:"reasoning"`
         Thinking        json.RawMessage `json:"thinking"`
+        WebSearch       *bool           `json:"webSearch"`
+        AdvancedSearch  *bool           `json:"advancedSearch"`
         Tools           json.RawMessage `json:"tools"`
         ReasoningEffort string          `json:"reasoning_effort"`
     }
@@ -433,6 +448,20 @@ func anthropicMessagesHandler(w http.ResponseWriter, r *http.Request) {
     } else if len(body.Thinking) > 0 {
         enabled := thinkingEnabled(body.Thinking)
         opts.Thinking = &enabled
+    }
+
+    if body.WebSearch != nil {
+        opts.WebSearch = body.WebSearch
+    }
+    // Advanced Search implies web search (same coupling as the OpenAI
+    // endpoint — Advanced Search is only reachable behind the web-search
+    // toggle on chat.z.ai). The agent-mode gate in sendToZAI still wins.
+    if body.AdvancedSearch != nil {
+        opts.AdvancedSearch = body.AdvancedSearch
+        if *body.AdvancedSearch && opts.WebSearch == nil {
+            on := true
+            opts.WebSearch = &on
+        }
     }
 
     if stream {

--- a/internal/zbridge/captcha.go
+++ b/internal/zbridge/captcha.go
@@ -595,7 +595,17 @@ func (c *CaptchaCache) generate() {
 // CAPTCHA VERIFICATION PARAM — IN-MEMORY (no FIFO / named pipe)
 // ============================================================================
 
+// captchaParamOverride, when non-empty, is returned by getCaptchaVerifyParam
+// instead of hitting the real Aliyun machinery. It is a test seam in the
+// same spirit as wafProbeTransport (waf.go): whitebox tests set it to
+// drive sendToZAI against a mock upstream without agent mode (the cache
+// path is agent-mode only). Production never sets it.
+var captchaParamOverride string
+
 func getCaptchaVerifyParam() (string, error) {
+    if captchaParamOverride != "" {
+        return captchaParamOverride, nil
+    }
     if config.AgentMode {
         if val, ok := captchaCache.Get(); ok {
             logInfo("[Captcha Cache] hit - using cached param")

--- a/internal/zbridge/handlers.go
+++ b/internal/zbridge/handlers.go
@@ -27,6 +27,7 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
         Thinking        json.RawMessage `json:"thinking"`
         WebSearch       *bool           `json:"webSearch"`
         Search          *bool           `json:"search"`
+        AdvancedSearch  *bool           `json:"advancedSearch"`
         Tools           json.RawMessage `json:"tools"`
         ToolChoice      json.RawMessage `json:"tool_choice"`
         ReasoningEffort string          `json:"reasoning_effort"`
@@ -151,6 +152,18 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
         opts.WebSearch = body.WebSearch
     } else if body.Search != nil {
         opts.WebSearch = body.Search
+    }
+    // Advanced Search (the MCP "advanced-search" server from chat.z.ai)
+    // rides on top of web search — turn the base toggle on with it, exactly
+    // like the web UI does (Advanced Search is only reachable when the
+    // globe/web-search mode is on). The agent-mode gate in sendToZAI still
+    // force-disables both when agent mode is active.
+    if body.AdvancedSearch != nil {
+        opts.AdvancedSearch = body.AdvancedSearch
+        if *body.AdvancedSearch && opts.WebSearch == nil {
+            on := true
+            opts.WebSearch = &on
+        }
     }
 
     if stream {

--- a/internal/zbridge/testhooks.go
+++ b/internal/zbridge/testhooks.go
@@ -35,6 +35,8 @@ func OverrideSessionState(token, userID string, initialized bool) func() {
 // SeedCaptchaParam pushes a ready-made captcha_verify_param into the
 // agent-mode cache so requests can bypass the Aliyun captcha machinery
 // (integration tests only — the live cache is fed by captchaCache.Run).
+// Only serves requests that run with agent mode on: the cache path in
+// getCaptchaVerifyParam is agent-mode only.
 func SeedCaptchaParam(value string) {
     captchaCache.mu.Lock()
     captchaCache.params = append(captchaCache.params, cachedCaptcha{
@@ -42,6 +44,17 @@ func SeedCaptchaParam(value string) {
         generatedAt: time.Now(),
     })
     captchaCache.mu.Unlock()
+}
+
+// OverrideCaptchaParam makes getCaptchaVerifyParam return the given value
+// unconditionally (no Aliyun call, no cache), regardless of agent mode —
+// the blackbox equivalent of the whitebox captchaParamOverride seam. The
+// returned function restores the previous state. Integration tests use it
+// to drive the non-agent request path against a mock upstream.
+func OverrideCaptchaParam(value string) func() {
+    prev := captchaParamOverride
+    captchaParamOverride = value
+    return func() { captchaParamOverride = prev }
 }
 
 // FlushModelsCache clears the cached model list so the next /v1/models (or

--- a/internal/zbridge/types.go
+++ b/internal/zbridge/types.go
@@ -51,6 +51,13 @@ type ZAIResult struct {
 type SendOptions struct {
     Model             string
     WebSearch         *bool
+    // AdvancedSearch enables Z.AI's "Advanced Search" (the MCP variant of
+    // web search from chat.z.ai): it attaches the top-level
+    // "mcp_servers": ["advanced-search"] field to the upstream
+    // /api/v2/chat/completions payload. Requires WebSearch to be on too —
+    // the web UI only exposes Advanced Search behind the globe icon.
+    // Ignored (forced off) when agent mode is active (issue #42).
+    AdvancedSearch    *bool
     Thinking          *bool
     ImageGen          *bool
     PreviewMode       *bool

--- a/internal/zbridge/waf_test.go
+++ b/internal/zbridge/waf_test.go
@@ -193,6 +193,7 @@ func TestBreakerStopsCaptchaSpend(t *testing.T) {
         ClientMessagesRaw json.RawMessage
         Files             []map[string]interface{}
         RequestID         string
+        AdvancedSearch    bool
     }{Model: "glm-4.7", ChatID: "chat-1"}
     err := sendToZAIStream("probe test", opts, make(chan ZAIResult, 1))
     if err == nil {

--- a/internal/zbridge/websearch_test.go
+++ b/internal/zbridge/websearch_test.go
@@ -1,0 +1,440 @@
+package zbridge
+
+// Issue #42 regression tests: the shape of the upstream completions payload
+// for web search / advanced search, and the agent-mode gate.
+//
+// Facts these tests pin (captured from the real chat.z.ai frontend):
+//   - "web_search" inside features is ALWAYS false upstream; the only key
+//     that toggles the built-in WebSearch is "auto_web_search".
+//   - "Advanced Search" is an MCP server: when enabled, the web client adds
+//     a top-level "mcp_servers": ["advanced-search"] field to the
+//     completions payload, on the same level as captcha_verify_param.
+//   - Agent mode always disables web search, even when the request asked
+//     for it (the agent shim's tool contract and Z.AI's internal
+//     tool-call loop cannot be mixed).
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// captureUpstreamRequest spins a mock Z.AI upstream that records the JSON
+// body of every POST /api/v2/chat/completions and answers with a minimal
+// SSE stream. It returns the server and a function to read the last
+// captured request body.
+func captureUpstreamRequest(t *testing.T) (*httptest.Server, func() map[string]interface{}) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var lastBody map[string]interface{}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		mu.Lock()
+		lastBody = parsed
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprintf(w, "data: {\"data\":{\"delta_content\":\"ok\"}}\n\n")
+		fmt.Fprintf(w, "data: {\"data\":{\"phase\":\"done\"}}\n\n")
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+
+	read := func() map[string]interface{} {
+		mu.Lock()
+		defer mu.Unlock()
+		if lastBody == nil {
+			t.Fatal("upstream never received a completion request")
+		}
+		return lastBody
+	}
+	return upstream, read
+}
+
+// runCompletionThroughSendToZAI drives sendToZAI (the real feature
+// resolution + payload build) against the given mock upstream and drains
+// the result channel. The captcha machinery is bypassed via the
+// captchaParamOverride test seam (the agent-mode cache only serves
+// agent-mode requests).
+func runCompletionThroughSendToZAI(t *testing.T, opts SendOptions) {
+	t.Helper()
+
+	SeedCaptchaParam("test-captcha-param")
+
+	ch, err := sendToZAI("test prompt", opts)
+	if err != nil {
+		t.Fatalf("sendToZAI: %v", err)
+	}
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case res, ok := <-ch:
+			if !ok {
+				return // stream finished
+			}
+			if res.Err != nil {
+				t.Fatalf("upstream stream error: %v", res.Err)
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the upstream stream to finish")
+		}
+	}
+}
+
+// websearchTestEnv points the bridge at the mock upstream, bypasses guest
+// auth, and bypasses the captcha machinery. It returns a restore function.
+//
+// Pacing is switched off for these tests (UPSTREAM_MIN_INTERVAL_MS=0, the
+// same trick as tests/main_test.go): they talk to a local mock upstream
+// and would otherwise pay the 200-500 ms inter-request gap on every call,
+// slowing the package and disturbing the timing-sensitive pacing tests
+// that run in parallel packages.
+func websearchTestEnv(t *testing.T, upstream *httptest.Server) func() {
+	t.Helper()
+
+	t.Setenv("UPSTREAM_MIN_INTERVAL_MS", "0")
+
+	oldBase := BASE_URL
+	BASE_URL = upstream.URL
+	restoreSession := OverrideSessionState("test-token", "test-user", true)
+	oldCaptchaOverride := captchaParamOverride
+	captchaParamOverride = "test-captcha-param"
+
+	return func() {
+		BASE_URL = oldBase
+		captchaParamOverride = oldCaptchaOverride
+		restoreSession()
+	}
+}
+
+func websearchBoolPtr(b bool) *bool { return &b }
+
+// webSearchTrue_leavesWebSearchFalse pins the core issue #42 discovery:
+// enabling web search must set auto_web_search=true and keep web_search
+// at false — sending web_search=true upstream does nothing (the server
+// always mirrors it back as false) and only confuses clients.
+func TestWebSearchToggleSetsAutoWebSearchOnly(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	on := true
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:     "glm-4.7",
+		ChatID:    "chat-websearch-1",
+		WebSearch: &on,
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (the real WebSearch toggle)", features["auto_web_search"])
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false (upstream always reports false; only auto_web_search toggles WebSearch)", features["web_search"])
+	}
+	if _, present := body["mcp_servers"]; present {
+		t.Errorf("mcp_servers present on a plain web-search request: %v — Advanced Search must be requested explicitly", body["mcp_servers"])
+	}
+}
+
+// webSearchFalse_disablesAutoWebSearch pins that an explicit webSearch
+// false strips auto_web_search from the features payload.
+func TestWebSearchFalseRemovesAutoWebSearch(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	off := false
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:     "glm-4.7",
+		ChatID:    "chat-websearch-2",
+		WebSearch: &off,
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, present := features["auto_web_search"]; present {
+		t.Errorf("auto_web_search present (%v) on a webSearch=false request, want it removed", v)
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+}
+
+// defaultRequest_noSearchKeys: with neither flag set, the payload must not
+// carry auto_web_search at all and web_search stays false.
+func TestDefaultRequestCarriesNoSearchFeatures(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:  "glm-4.7",
+		ChatID: "chat-websearch-3",
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, present := features["auto_web_search"]; present {
+		t.Errorf("auto_web_search present (%v) on a default request, want it removed", v)
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+	if _, present := body["mcp_servers"]; present {
+		t.Errorf("mcp_servers present on a default request: %v", body["mcp_servers"])
+	}
+}
+
+// advancedSearch_addsMcpServersField pins the wire shape captured from the
+// real chat.z.ai web client: Advanced Search adds
+// "mcp_servers": ["advanced-search"] at the TOP LEVEL of the completions
+// payload (same level as captcha_verify_param), not inside features.
+func TestAdvancedSearchAddsMcpServersField(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	on := true
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:          "glm-4.7",
+		ChatID:         "chat-websearch-4",
+		WebSearch:      &on,
+		AdvancedSearch: &on,
+	})
+
+	body := readBody()
+
+	// Top level, same level as captcha_verify_param.
+	mcpRaw, present := body["mcp_servers"]
+	if !present {
+		t.Fatalf("mcp_servers missing from the completions payload with Advanced Search on; body keys: %v", bodyKeys(body))
+	}
+	mcp, ok := mcpRaw.([]interface{})
+	if !ok || len(mcp) != 1 {
+		t.Fatalf("mcp_servers = %#v, want [\"advanced-search\"]", mcpRaw)
+	}
+	if mcp[0] != "advanced-search" {
+		t.Fatalf("mcp_servers = %#v, want [\"advanced-search\"]", mcpRaw)
+	}
+	if _, present := body["captcha_verify_param"]; !present {
+		t.Errorf("captcha_verify_param missing — mcp_servers must sit on the same payload level")
+	}
+
+	// Advanced Search rides on top of the base web-search toggle.
+	features, _ := body["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true when Advanced Search is on (it runs behind the web-search mode)", features["auto_web_search"])
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+	if _, present := features["mcp_servers"]; present {
+		t.Errorf("mcp_servers also present inside features — it is a top-level payload field, not a feature")
+	}
+}
+
+// advancedSearch_alone_stillEnablesWebSearch: the handlers auto-enable the
+// base web-search toggle when Advanced Search is requested (same coupling
+// as the web UI, where Advanced Search hides behind the globe). This pins
+// the sendToZAI side of that contract: with both flags on (what the handler
+// passes down), auto_web_search is set and mcp_servers is attached.
+func TestAdvancedSearchAloneStillEnablesWebSearch(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	on := true
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:          "glm-4.7",
+		ChatID:         "chat-websearch-5",
+		WebSearch:      &on, // handler auto-enabled (advancedSearch implies it)
+		AdvancedSearch: &on,
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (Advanced Search implies web search)", features["auto_web_search"])
+	}
+	if _, present := body["mcp_servers"]; !present {
+		t.Errorf("mcp_servers missing with Advanced Search on")
+	}
+}
+
+// advancedSearch_off_leavesNoMcpServers: an explicit advancedSearch=false
+// must not attach mcp_servers even when webSearch stays on.
+func TestAdvancedSearchFalseLeavesNoMcpServers(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	on := true
+	off := false
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:          "glm-4.7",
+		ChatID:         "chat-websearch-5b",
+		WebSearch:      &on,
+		AdvancedSearch: &off,
+	})
+
+	body := readBody()
+	if _, present := body["mcp_servers"]; present {
+		t.Errorf("mcp_servers present (%v) with Advanced Search explicitly off", body["mcp_servers"])
+	}
+	features, _ := body["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (webSearch on, advancedSearch off)", features["auto_web_search"])
+	}
+}
+
+// agentMode_forcesWebSearchOff pins the gate from the task: with agent mode
+// active, web search (and Advanced Search) are always disabled, even when
+// the request explicitly asked for them. Z.AI serves WebSearch through an
+// internal tool-call loop; mixing that with the agent shim's own tool
+// contract makes the model emit internal markers (retrieve/open_url) as if
+// they were the caller's tools.
+func TestAgentModeForcesWebSearchOff(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	oldAgentMode := config.AgentMode
+	config.AgentMode = true
+	defer func() { config.AgentMode = oldAgentMode }()
+
+	on := true
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:          "glm-4.7",
+		ChatID:         "chat-websearch-6",
+		WebSearch:      &on,
+		AdvancedSearch: &on,
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, present := features["auto_web_search"]; present {
+		t.Errorf("auto_web_search present (%v) with agent mode on, want it stripped", v)
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v with agent mode on, want false", features["web_search"])
+	}
+	if _, present := body["mcp_servers"]; present {
+		t.Errorf("mcp_servers present (%v) with agent mode on, want it stripped", body["mcp_servers"])
+	}
+}
+
+// web_search_ignoredAsStoredFeature: even if a stored per-model override
+// (or server capability copied by IncludeAll) sneaks web_search=true into
+// the resolved feature map, the payload build must pin it back to false —
+// only auto_web_search controls WebSearch upstream.
+func TestWebSearchFeatureKeyAlwaysPinnedFalse(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	// Inject a stored override as if a user had POSTed it to /features.
+	modelFeatureStatesMu.Lock()
+	prev, existed := modelFeatureStates["glm-4.7"]
+	modelFeatureStates["glm-4.7"] = &ModelFeatureState{
+		IncludeAll: false,
+		Overrides: map[string]interface{}{
+			"web_search":      true, // must be pinned back to false
+			"auto_web_search": true,
+		},
+	}
+	modelFeatureStatesMu.Unlock()
+	defer func() {
+		modelFeatureStatesMu.Lock()
+		if existed {
+			modelFeatureStates["glm-4.7"] = prev
+		} else {
+			delete(modelFeatureStates, "glm-4.7")
+		}
+		modelFeatureStatesMu.Unlock()
+	}()
+
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:  "glm-4.7",
+		ChatID: "chat-websearch-7",
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v despite the stored override, want false (pinned by the payload build)", features["web_search"])
+	}
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (stored override is respected)", features["auto_web_search"])
+	}
+}
+
+func bodyKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// agentMode_disabledRequest keeps working: the gate must not break the
+// normal no-search path when agent mode is on.
+func TestAgentModePlainRequestStillClean(t *testing.T) {
+	upstream, readBody := captureUpstreamRequest(t)
+	defer upstream.Close()
+	restore := websearchTestEnv(t, upstream)
+	defer restore()
+
+	oldAgentMode := config.AgentMode
+	config.AgentMode = true
+	defer func() { config.AgentMode = oldAgentMode }()
+
+	runCompletionThroughSendToZAI(t, SendOptions{
+		Model:  "glm-4.7",
+		ChatID: "chat-websearch-8",
+	})
+
+	body := readBody()
+	features, _ := body["features"].(map[string]interface{})
+	if v, present := features["auto_web_search"]; present {
+		t.Errorf("auto_web_search present (%v) on an agent-mode request without search, want stripped", v)
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+	if _, present := body["mcp_servers"]; present {
+		t.Errorf("mcp_servers present on a request without Advanced Search: %v", body["mcp_servers"])
+	}
+}

--- a/internal/zbridge/zai.go
+++ b/internal/zbridge/zai.go
@@ -285,16 +285,54 @@ func sendToZAI(prompt string, opts SendOptions) (<-chan ZAIResult, error) {
     // (server defaults + stored user overrides)
     featuresMap := resolveFeaturesForModel(model)
 
-    // Apply per-request overrides (highest precedence)
+    // Apply per-request overrides (highest precedence).
+    //
+    // Issue #42: Z.AI's completions payload has TWO search-related feature
+    // keys, but only one of them does anything:
+    //   - auto_web_search — the real toggle for the model's built-in
+    //     WebSearch feature (the globe icon on chat.z.ai)
+    //   - web_search      — always false upstream; sending true here does
+    //     NOT enable anything (it's just mirrored back by the server)
+    // So the webSearch request flag now toggles auto_web_search only, and
+    // web_search is pinned to false in every request (see the payload
+    // build in sendToZAIStream). "Advanced Search" on chat.z.ai is a
+    // different thing entirely — it's an MCP server, opted into per
+    // request via the top-level "mcp_servers": ["advanced-search"] field
+    // (see SendOptions.AdvancedSearch).
+    webSearch := false
+    advancedSearch := false
     if opts.WebSearch != nil {
-        if *opts.WebSearch {
-            featuresMap["auto_web_search"] = true
-            featuresMap["web_search"] = true
-        } else {
-            delete(featuresMap, "auto_web_search")
-            delete(featuresMap, "web_search")
-        }
+        webSearch = *opts.WebSearch
     }
+    if opts.AdvancedSearch != nil {
+        advancedSearch = *opts.AdvancedSearch
+    }
+    if config.AgentMode {
+        // Issue #42 gate: agent mode folds tools & roles into a single
+        // user-only prompt. Z.AI serves the built-in WebSearch through an
+        // internal tool-call loop on its side; mixing that with the agent
+        // shim's own tool contract confuses the model (it starts emitting
+        // internal tool_call markers like retrieve/open_url as if they were
+        // the caller's tools, or refuses to search at all). So: agent mode
+        // always wins and web search stays off, even when the request
+        // asked for it.
+        if webSearch || advancedSearch {
+            logInfo("[web_search] agent mode active — disabling web search for this request")
+        }
+        webSearch = false
+        advancedSearch = false
+    }
+    if webSearch {
+        featuresMap["auto_web_search"] = true
+    } else if opts.WebSearch != nil || config.AgentMode {
+        // Only strip auto_web_search when the request explicitly turned it
+        // off, or when the agent-mode gate forces it off — otherwise the
+        // stored per-model overrides (POST /features) keep working.
+        delete(featuresMap, "auto_web_search")
+    }
+    // web_search is never set to true upstream — auto_web_search is the
+    // only working toggle (issue #42). The payload build pins it to false.
+    delete(featuresMap, "web_search")
     if opts.Thinking != nil {
         featuresMap["enable_thinking"] = *opts.Thinking
     }
@@ -359,6 +397,7 @@ func sendToZAI(prompt string, opts SendOptions) (<-chan ZAIResult, error) {
         ClientMessagesRaw json.RawMessage
         Files             []map[string]interface{}
         RequestID         string
+        AdvancedSearch    bool
     }{
         Model:             model,
         ChatID:            chatID,
@@ -367,6 +406,7 @@ func sendToZAI(prompt string, opts SendOptions) (<-chan ZAIResult, error) {
         ClientMessagesRaw: opts.ClientMessagesRaw,
         Files:             opts.Files,
         RequestID:         opts.RequestID,
+        AdvancedSearch:    advancedSearch,
     }
 
     ch := make(chan ZAIResult, 100)
@@ -387,6 +427,7 @@ func sendToZAIStream(prompt string, opts struct {
     ClientMessagesRaw json.RawMessage
     Files             []map[string]interface{}
     RequestID         string
+    AdvancedSearch    bool
 }, ch chan<- ZAIResult) error {
 
     for attempt := 0; attempt < 2; attempt++ {
@@ -440,6 +481,9 @@ func sendToZAIStream(prompt string, opts struct {
         featuresPayload["flags"] = []interface{}{}
         // image_generation is ALWAYS false
         featuresPayload["image_generation"] = false
+        // web_search is always false — auto_web_search is the only working
+        // web-search toggle upstream (issue #42).
+        featuresPayload["web_search"] = false
 
         requestBody := map[string]interface{}{
             "model":                opts.Model,
@@ -454,6 +498,18 @@ func sendToZAIStream(prompt string, opts struct {
         // requests keep the exact body shape they always had.
         if len(opts.Files) > 0 {
             requestBody["files"] = opts.Files
+        }
+        // Issue #42: "Advanced Search" on chat.z.ai is an MCP server. When
+        // enabled in the web UI, the frontend adds a top-level
+        // "mcp_servers": ["advanced-search"] field to the completions
+        // payload (same level as captcha_verify_param), and the model then
+        // runs its searches through the advanced-search MCP tools
+        // (internal tool calls like retrieve/open_url show up in the SSE
+        // stream, answered server-side by Z.AI). Only attach the field when
+        // it's on — a plain web-search request keeps the exact body shape
+        // the web client sends.
+        if opts.AdvancedSearch {
+            requestBody["mcp_servers"] = []string{"advanced-search"}
         }
 
         bodyBytes, _ := json.Marshal(requestBody)

--- a/tests/websearch_e2e_test.go
+++ b/tests/websearch_e2e_test.go
@@ -1,0 +1,275 @@
+// Blackbox end-to-end regression tests for issue #42 through the REAL HTTP
+// stack, driven via the exported zbridge.NewHandler() surface:
+//
+//   NewHandler -> authMiddleware -> chatCompletionsHandler -> sendToZAI ->
+//   sendToZAIStream -> upstream POST body on the wire.
+//
+// These pin the externally visible contract of the search flags:
+//   - webSearch=true  -> features.auto_web_search=true, features.web_search=false
+//   - advancedSearch=true -> top-level mcp_servers:["advanced-search"]
+//   - agent mode on -> both search toggles are force-disabled server-side
+//     (the request still succeeds — it just never asks Z.AI to search).
+//
+// The upstream is a local httptest mock; the captcha machinery is bypassed
+// via the captchaParamOverride seam (whitebox tests own it; here it is set
+// through the exported test surface indirectly by keeping agent mode on for
+// the gate test and using the cache for the others).
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"zai-api/internal/zbridge"
+)
+
+// captureBodyUpstream records the last /api/v2/chat/completions JSON body.
+type capturedBody struct {
+	mu   sync.Mutex
+	body map[string]interface{}
+}
+
+func (c *capturedBody) record(raw []byte) error {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.body = parsed
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *capturedBody) get(t *testing.T) map[string]interface{} {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.body == nil {
+		t.Fatal("upstream never received a completion request")
+	}
+	return c.body
+}
+
+func newCaptureUpstream(t *testing.T) (*httptest.Server, *capturedBody) {
+	t.Helper()
+	cap := &capturedBody{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		if err := cap.record(raw); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprintf(w, "data: {\"data\":{\"delta_content\":\"ok\"}}\n\n")
+		fmt.Fprintf(w, "data: {\"data\":{\"phase\":\"done\"}}\n\n")
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
+
+// driveChatCompletion posts a /v1/chat/completions body through the real
+// handler and returns the response recorder.
+func driveChatCompletion(t *testing.T, cfg *zbridge.Config, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.Auth.Token)
+	rec := httptest.NewRecorder()
+	zbridge.NewHandler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	return rec
+}
+
+// endToEndSearchEnv points the bridge at the mock, pre-seeds the session
+// (skipping guest auth), and bypasses the captcha machinery for BOTH the
+// agent and non-agent request paths (OverrideCaptchaParam). Returns the
+// config so callers can toggle agent mode and restore it.
+func endToEndSearchEnv(t *testing.T, upstream *httptest.Server) *zbridge.Config {
+	t.Helper()
+
+	oldBase := zbridge.BASE_URL
+	zbridge.BASE_URL = upstream.URL
+	t.Cleanup(func() { zbridge.BASE_URL = oldBase })
+
+	restore := zbridge.OverrideSessionState("test-token", "test-user", true)
+	t.Cleanup(restore)
+
+	restoreCaptcha := zbridge.OverrideCaptchaParam("test-captcha-param")
+	t.Cleanup(restoreCaptcha)
+
+	cfg := zbridge.GetConfig()
+	oldAgentMode := cfg.AgentMode
+	t.Cleanup(func() { cfg.AgentMode = oldAgentMode })
+
+	return cfg
+}
+
+// HTTPEndToEnd: webSearch=true must reach the upstream as
+// auto_web_search=true with web_search pinned false (issue #42: only
+// auto_web_search controls the WebSearch feature; web_search upstream is
+// always false).
+func TestHTTPEndToEndWebSearchPayload(t *testing.T) {
+	upstream, cap := newCaptureUpstream(t)
+	cfg := endToEndSearchEnv(t, upstream)
+	cfg.AgentMode = false
+
+	body := `{"model":"glm-4.7","stream":false,"webSearch":true,"messages":[{"role":"user","content":"hi"}]}`
+	driveChatCompletion(t, cfg, body)
+
+	got := cap.get(t)
+	features, _ := got["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (webSearch flag must toggle it)", features["auto_web_search"])
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false (upstream always reports false; only auto_web_search toggles WebSearch)", features["web_search"])
+	}
+	if _, present := got["mcp_servers"]; present {
+		t.Errorf("mcp_servers present (%v) on a plain web-search request — Advanced Search is separate and opt-in", got["mcp_servers"])
+	}
+}
+
+// HTTPEndToEnd: advancedSearch=true must add the top-level
+// mcp_servers:["advanced-search"] field captured from the real chat.z.ai
+// frontend (same payload level as captcha_verify_param), and auto-enable
+// the base web-search toggle.
+func TestHTTPEndToEndAdvancedSearchPayload(t *testing.T) {
+	upstream, cap := newCaptureUpstream(t)
+	cfg := endToEndSearchEnv(t, upstream)
+	cfg.AgentMode = false
+
+	body := `{"model":"glm-4.7","stream":false,"advancedSearch":true,"messages":[{"role":"user","content":"hi"}]}`
+	driveChatCompletion(t, cfg, body)
+
+	got := cap.get(t)
+	mcpRaw, present := got["mcp_servers"]
+	if !present {
+		t.Fatalf("mcp_servers missing from the upstream payload with advancedSearch=true; body keys: %v", keysOf(got))
+	}
+	mcp, ok := mcpRaw.([]interface{})
+	if !ok || len(mcp) != 1 || mcp[0] != "advanced-search" {
+		t.Fatalf("mcp_servers = %#v, want [\"advanced-search\"]", mcpRaw)
+	}
+	if _, present := got["captcha_verify_param"]; !present {
+		t.Errorf("captcha_verify_param missing — mcp_servers must sit at the same payload level")
+	}
+
+	// The base toggle is auto-enabled with it (same coupling as the web UI).
+	features, _ := got["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (advancedSearch implies web search)", features["auto_web_search"])
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+}
+
+// HTTPEndToEnd: with agent mode on, the search flags are ignored — the
+// upstream payload carries no auto_web_search and no mcp_servers even
+// though the request asked for both. The request itself must still succeed
+// (the client just doesn't get server-side search).
+func TestHTTPEndToEndAgentModeGatesWebSearch(t *testing.T) {
+	upstream, cap := newCaptureUpstream(t)
+	cfg := endToEndSearchEnv(t, upstream)
+	cfg.AgentMode = true
+
+	body := `{"model":"glm-4.7","stream":false,"webSearch":true,"advancedSearch":true,"messages":[{"role":"user","content":"hi"}]}`
+	driveChatCompletion(t, cfg, body)
+
+	got := cap.get(t)
+	features, _ := got["features"].(map[string]interface{})
+	if v, present := features["auto_web_search"]; present {
+		t.Errorf("auto_web_search present (%v) with agent mode on, want it stripped", v)
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v with agent mode on, want false", features["web_search"])
+	}
+	if _, present := got["mcp_servers"]; present {
+		t.Errorf("mcp_servers present (%v) with agent mode on, want it stripped", got["mcp_servers"])
+	}
+}
+
+// HTTPEndToEnd: the "search" alias must behave exactly like "webSearch".
+func TestHTTPEndToEndSearchAliasPayload(t *testing.T) {
+	upstream, cap := newCaptureUpstream(t)
+	cfg := endToEndSearchEnv(t, upstream)
+	cfg.AgentMode = false
+
+	body := `{"model":"glm-4.7","stream":false,"search":true,"messages":[{"role":"user","content":"hi"}]}`
+	driveChatCompletion(t, cfg, body)
+
+	got := cap.get(t)
+	features, _ := got["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true (the search alias must toggle it too)", features["auto_web_search"])
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+}
+
+// HTTPEndToEnd: the Anthropic /v1/messages endpoint accepts the same
+// non-standard flags and they must land in the same upstream payload shape.
+func TestHTTPEndToEndAnthropicSearchFlags(t *testing.T) {
+	upstream, cap := newCaptureUpstream(t)
+	cfg := endToEndSearchEnv(t, upstream)
+	cfg.AgentMode = false
+
+	body := `{"model":"glm-4.7","stream":false,"max_tokens":64,"webSearch":true,"advancedSearch":true,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", cfg.Auth.Token)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	rec := httptest.NewRecorder()
+	zbridge.NewHandler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	got := cap.get(t)
+	mcpRaw, present := got["mcp_servers"]
+	if !present {
+		t.Fatalf("mcp_servers missing from the upstream payload for the Anthropic request; body keys: %v", keysOf(got))
+	}
+	mcp, ok := mcpRaw.([]interface{})
+	if !ok || len(mcp) != 1 || mcp[0] != "advanced-search" {
+		t.Fatalf("mcp_servers = %#v, want [\"advanced-search\"]", mcpRaw)
+	}
+	features, _ := got["features"].(map[string]interface{})
+	if v, _ := features["auto_web_search"].(bool); !v {
+		t.Errorf("auto_web_search = %v, want true", features["auto_web_search"])
+	}
+	if v, _ := features["web_search"].(bool); v {
+		t.Errorf("web_search = %v, want false", features["web_search"])
+	}
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #42

Spent some time with devtools on chat.z.ai to figure out what's actually going on with the search stuff, and it turned out there were three separate things tangled together:

**1. The `webSearch` flag was half broken.** It sent `web_search: true` along with `auto_web_search: true` in the features payload, but upstream `web_search` is *always* false — it just gets mirrored back and does nothing. `auto_web_search` is the only key that actually toggles the WebSearch feature. So the flag now sets `auto_web_search` only, and `web_search` is pinned to `false` on every request (even stored `/features` overrides can't sneak a `true` back in).

**2. Advanced Search is now supported.** It's not a feature flag at all — it's an MCP server. When you enable it on the web, the frontend adds a new top-level field to the completions payload:

```json
{
  "captcha_verify_param": "...",
  "mcp_servers": ["advanced-search"],
  "features": { "auto_web_search": true }
}
```

`servers` sits on the same level as `captcha_verify_param`, not inside `features`. Sending `advancedSearch: true` on `/v1/chat/completions` (or `/v1/messages`) now adds exactly that field, and turns the base web-search toggle on with it — same coupling as the web UI, where Advanced Search hides behind the globe icon. The internal tool calls you see in the stream during a search (`retrieve`, `open_url`, ...) are Z.AI's MCP loop running server-side; the final answer arrives as normal content with the 【turn0search0】 citation markers. The internal tool calls are unrelated to agent-mode tool calling — nothing was mixed there.

**3. Web search is force-disabled in agent mode.** Z.AI serves WebSearch through its own internal tool-call loop, and mixing that with the agent shim's tool contract made the model emit internal markers as if they were the caller's tools, or just refuse to search (the "it says it's not capable" behavior from the issue). So when agent mode is on, both search toggles are ignored — the request still succeeds, it just runs without server-side search. If you need tools and search in the same conversation, use the client's own fetch tools for the pages.

Whitebox tests in `internal/zbridge/websearch_test.go` pin all the payload shapes (including the agent gate), and `tests/websearch_e2e_test.go` drives the same contract through the real HTTP stack. Also added an `OverrideCaptchaParam` test seam so the non-agent request path can be tested against a mock upstream (the captcha cache only serves agent-mode requests).

Left out of this run on purpose: the sources/references pills and the References tab need the citations data exposed separately, and non-image file uploads are their own chunk of work — both should get their own PR rather than being rushed in here.